### PR TITLE
Runtime issues fix pr

### DIFF
--- a/admin/features/assistant/components/assistant-chat-shell.tsx
+++ b/admin/features/assistant/components/assistant-chat-shell.tsx
@@ -3,13 +3,23 @@ import { MessageSquarePlus, Mic, Paperclip, PanelRightClose, PanelRightOpen, Squ
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Image, Pressable, ScrollView, Text, TextInput, View, useWindowDimensions } from 'react-native';
 import { AppButton } from '@admin/components/ui';
+import { ApiError } from '@admin/lib/api';
+import { queryClient, queryKeys } from '@admin/lib/query';
 import {
   useAssistantConversationQuery,
   useAssistantConversationsQuery,
   useAssistantDecisionMutation,
 } from '../hooks';
 import { assistantService } from '../services';
+import {
+  appendAssistantConversationMessage,
+  createOptimisticUserMessage,
+  mergeAssistantConversationPage,
+  removeAssistantConversationMessage,
+  updateAssistantConversationSummaryCache,
+} from '../services/assistant-cache';
 import { AssistantMessageBlocks } from './assistant-message-blocks';
+import type { AssistantConversation, AssistantConversationSummary, AssistantMessage } from '../types/assistant.types';
 
 type Attachment = {
   id: string;
@@ -42,6 +52,12 @@ type WebSpeechRecognitionInstance = {
 
 type WebSpeechRecognitionConstructor = new () => WebSpeechRecognitionInstance;
 
+type StreamingAssistantState = {
+  text: string;
+  toolName: string | null;
+  approvalRequested: boolean;
+};
+
 function getSpeechRecognitionConstructor(): WebSpeechRecognitionConstructor | null {
   if (typeof window === 'undefined') return null;
 
@@ -72,6 +88,44 @@ const promptSuggestions = [
   'How do I receive a purchase order?',
 ];
 
+function buildStreamingAssistantBlocks(streamingState: StreamingAssistantState | null) {
+  if (!streamingState) return [];
+
+  const blocks: AssistantMessage['blocks'] = [];
+  if (streamingState.text.trim()) {
+    blocks.push({ type: 'text', content: streamingState.text.trim() });
+  } else if (streamingState.toolName) {
+    blocks.push({ type: 'text', content: `Running ${streamingState.toolName}...` });
+  } else if (streamingState.approvalRequested) {
+    blocks.push({ type: 'text', content: 'Approval requested.' });
+  } else {
+    blocks.push({ type: 'text', content: 'Thinking...' });
+  }
+
+  return blocks;
+}
+
+function getAssistantErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof ApiError) {
+    if (error.code === 'REQUEST_ABORTED') {
+      return null;
+    }
+    if (error.code === 'REQUEST_TIMEOUT' || error.code === 'NETWORK_ERROR' || error.status === 0) {
+      return 'Connection problem. Please retry.';
+    }
+    if (error.status >= 400 && error.status < 500) {
+      return `Assistant error: ${error.message}`;
+    }
+    return error.message || fallback;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
 export function AssistantChatShell({
   mode,
   conversationId,
@@ -91,12 +145,15 @@ export function AssistantChatShell({
   const [isHistoryRailOpen, setIsHistoryRailOpen] = useState(false);
   const [isStreamingRun, setIsStreamingRun] = useState(false);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [streamingAssistantState, setStreamingAssistantState] = useState<StreamingAssistantState | null>(null);
+  const [isLoadingOlderMessages, setIsLoadingOlderMessages] = useState(false);
 
   const scrollRef = useRef<ScrollView | null>(null);
   const lastAutoStartedPromptRef = useRef<string | null>(null);
   const recognitionRef = useRef<WebSpeechRecognitionInstance | null>(null);
   const recognitionCtorRef = useRef<WebSpeechRecognitionConstructor | null>(getSpeechRecognitionConstructor());
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const activeRunAbortRef = useRef<AbortController | null>(null);
 
   const isThreadMode = mode === 'thread' && Boolean(conversationId);
   const activeConversation = isThreadMode ? conversationQuery.data : undefined;
@@ -106,16 +163,68 @@ export function AssistantChatShell({
   const isDesktop = width >= 1280;
   const showHistoryRail = isDesktop ? isHistoryRailOpen : isHistoryRailOpen;
   const historyRailContainerClassName = isDesktop ? 'lg:w-[340px]' : 'w-full';
-
-  const refreshConversationViews = useCallback(async () => {
-    await Promise.all([
-      conversationsQuery.refetch(),
-      isThreadMode ? conversationQuery.refetch() : Promise.resolve(),
-    ]);
-  }, [conversationQuery, conversationsQuery, isThreadMode]);
+  const streamingAssistantBlocks = buildStreamingAssistantBlocks(streamingAssistantState);
 
   const attachmentsRef = useRef<Attachment[]>([]);
   attachmentsRef.current = attachments;
+
+  const invalidateAssistantDrivenQueries = useCallback(() => {
+    [
+      queryKeys.assistant.conversations(),
+      queryKeys.assistant.approvals(),
+      queryKeys.assistant.history(),
+      queryKeys.orders.sales(),
+      queryKeys.orders.purchase(),
+      queryKeys.products.all(),
+      queryKeys.inventory.stockOnHand(),
+      queryKeys.inventory.movements(),
+      queryKeys.inventory.receipts(),
+      queryKeys.settings.tenant(),
+      queryKeys.dashboard.overview(),
+    ].forEach((prefix) => queryClient.invalidateQueries(prefix));
+  }, []);
+
+  const reconcileConversationCache = useCallback(async (targetConversationId: string) => {
+    const latest = await assistantService.getConversation(targetConversationId, { messageLimit: 50 });
+    queryClient.setQueryData<AssistantConversation>(
+      queryKeys.assistant.conversation(targetConversationId),
+      (existing) => mergeAssistantConversationPage(existing, latest, 'replace-latest'),
+    );
+    queryClient.setQueryData<AssistantConversationSummary[]>(queryKeys.assistant.conversations(), (existing) =>
+      updateAssistantConversationSummaryCache(existing, latest),
+    );
+    return latest;
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      activeRunAbortRef.current?.abort();
+      activeRunAbortRef.current = null;
+    };
+  }, []);
+
+  const loadOlderMessages = useCallback(async () => {
+    if (!conversationId || !activeConversation?.messagePage?.hasMore || isLoadingOlderMessages) {
+      return;
+    }
+
+    setError(null);
+    setIsLoadingOlderMessages(true);
+    try {
+      const olderPage = await assistantService.getConversation(conversationId, {
+        beforeCreatedAt: activeConversation.messagePage.nextCursorCreatedAt ?? null,
+        beforeId: activeConversation.messagePage.nextCursorId ?? null,
+      });
+      queryClient.setQueryData<AssistantConversation>(
+        queryKeys.assistant.conversation(conversationId),
+        (existing) => mergeAssistantConversationPage(existing, olderPage, 'prepend-older'),
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load older messages.');
+    } finally {
+      setIsLoadingOlderMessages(false);
+    }
+  }, [activeConversation?.messagePage?.hasMore, activeConversation?.messagePage?.nextCursorCreatedAt, activeConversation?.messagePage?.nextCursorId, conversationId, isLoadingOlderMessages]);
 
   const handleAttach = useCallback(() => {
     fileInputRef.current?.click();
@@ -211,14 +320,18 @@ export function AssistantChatShell({
     setError(null);
     setStatusMessage(null);
     setIsStreamingRun(true);
+    activeRunAbortRef.current?.abort();
+    const runController = new AbortController();
+    activeRunAbortRef.current = runController;
 
     try {
       const hasAttachments = attachmentsRef.current.length > 0;
       let result: { runId: string | null; conversationId: string | null; workflowId: string | null };
+      let targetConversationId: string | null = null;
 
       if (hasAttachments) {
         const conversation = await assistantService.createConversation({ title: trimmedPrompt.slice(0, 60) });
-        const targetConversationId = conversation.conversation.id;
+        targetConversationId = conversation.conversation.id;
         const attachmentIds = await ensureUploadedAttachments(targetConversationId);
         result = await assistantService.streamRun(
           {
@@ -237,6 +350,7 @@ export function AssistantChatShell({
               setStatusMessage('Approval requested.');
             }
           },
+          { signal: runController.signal },
         );
       } else {
         result = await assistantService.streamRun(
@@ -255,22 +369,31 @@ export function AssistantChatShell({
               setStatusMessage('Approval requested.');
             }
           },
+          { signal: runController.signal },
         );
       }
 
       setPrompt('');
       setAttachments([]);
       setStatusMessage('Run completed.');
-      await conversationsQuery.refetch();
-      if (result.conversationId) {
-        router.replace(`/ai/thread/${result.conversationId}`);
+      const resolvedConversationId = targetConversationId ?? result.conversationId;
+      if (resolvedConversationId) {
+        await reconcileConversationCache(resolvedConversationId);
+        invalidateAssistantDrivenQueries();
+        router.replace(`/ai/thread/${resolvedConversationId}`);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to start conversation.');
+      const message = getAssistantErrorMessage(err, 'Failed to start conversation.');
+      if (message) {
+        setError(message);
+      }
     } finally {
+      if (activeRunAbortRef.current === runController) {
+        activeRunAbortRef.current = null;
+      }
       setIsStreamingRun(false);
     }
-  }, [conversationsQuery, ensureUploadedAttachments, router]);
+  }, [ensureUploadedAttachments, invalidateAssistantDrivenQueries, reconcileConversationCache, router]);
 
   const handleSend = useCallback(async () => {
     const trimmedPrompt = prompt.trim();
@@ -287,9 +410,20 @@ export function AssistantChatShell({
     setError(null);
     setStatusMessage(null);
     setIsStreamingRun(true);
+    setStreamingAssistantState({ text: '', toolName: null, approvalRequested: false });
+    activeRunAbortRef.current?.abort();
+    const runController = new AbortController();
+    activeRunAbortRef.current = runController;
+    let optimisticUserMessage: AssistantMessage | null = null;
 
     try {
       const attachmentIds = await ensureUploadedAttachments(conversationId);
+      optimisticUserMessage = createOptimisticUserMessage(trimmedPrompt);
+      queryClient.setQueryData<AssistantConversation>(
+        queryKeys.assistant.conversation(conversationId),
+        (existing) => appendAssistantConversationMessage(existing, optimisticUserMessage!),
+      );
+
       await assistantService.streamRun(
         { conversationId, content: trimmedPrompt, attachmentIds },
         async (event) => {
@@ -298,22 +432,66 @@ export function AssistantChatShell({
           }
           if (event.type === 'tool.called') {
             setStatusMessage(`Running ${String(event.payload?.toolName ?? 'tool')}...`);
+            setStreamingAssistantState((current) => ({
+              text: current?.text ?? '',
+              toolName: String(event.payload?.toolName ?? 'tool'),
+              approvalRequested: current?.approvalRequested ?? false,
+            }));
           }
           if (event.type === 'approval.requested') {
             setStatusMessage('Approval requested.');
+            setStreamingAssistantState((current) => ({
+              text: current?.text ?? '',
+              toolName: current?.toolName ?? null,
+              approvalRequested: true,
+            }));
+          }
+          if (event.type === 'assistant.message.delta') {
+            const nextChunk = String(event.payload?.content ?? '');
+            if (nextChunk) {
+              setStreamingAssistantState((current) => ({
+                text: `${current?.text ?? ''}${nextChunk}`,
+                toolName: current?.toolName ?? null,
+                approvalRequested: current?.approvalRequested ?? false,
+              }));
+            }
           }
         },
+        { signal: runController.signal },
       );
       setPrompt('');
       setAttachments([]);
       setStatusMessage('Run completed.');
-      await refreshConversationViews();
+      await reconcileConversationCache(conversationId);
+      invalidateAssistantDrivenQueries();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to send message.');
+      if (optimisticUserMessage) {
+        queryClient.setQueryData<AssistantConversation>(
+          queryKeys.assistant.conversation(conversationId),
+          (existing) => removeAssistantConversationMessage(existing, optimisticUserMessage!.id),
+        );
+      }
+
+      const message = getAssistantErrorMessage(err, 'Failed to send message.');
+      if (message) {
+        setError(message);
+      }
+
+      if (!(err instanceof ApiError && err.code === 'REQUEST_ABORTED')) {
+        try {
+          await reconcileConversationCache(conversationId);
+        } catch (reconcileError) {
+          console.error('Failed to reconcile assistant conversation cache after send error.', reconcileError);
+        }
+      }
     } finally {
+      if (activeRunAbortRef.current === runController) {
+        activeRunAbortRef.current = null;
+      }
+      setStreamingAssistantState(null);
       setIsStreamingRun(false);
     }
-  }, [conversationId, ensureUploadedAttachments, handleCreateConversation, isThreadMode, prompt, refreshConversationViews]);
+  }, [conversationId, ensureUploadedAttachments, handleCreateConversation, invalidateAssistantDrivenQueries, isThreadMode, prompt, reconcileConversationCache]);
 
   const handleDecision = useCallback(async (nextDecision: 'confirm' | 'cancel' | 'edit' | 'submit_for_approval') => {
     const workflowId = activeConversation?.workflow?.id;
@@ -328,16 +506,22 @@ export function AssistantChatShell({
     try {
       const result = await decision.mutateAsync({ workflowId, decision: nextDecision });
       setStatusMessage(result.message);
-      await refreshConversationViews();
+      if (conversationId) {
+        await reconcileConversationCache(conversationId);
+      }
+      invalidateAssistantDrivenQueries();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to apply workflow decision.');
     }
-  }, [activeConversation?.workflow?.id, decision, refreshConversationViews]);
+  }, [activeConversation?.workflow?.id, conversationId, decision, invalidateAssistantDrivenQueries, reconcileConversationCache]);
 
   const handleNewChat = useCallback(() => {
+    activeRunAbortRef.current?.abort();
+    activeRunAbortRef.current = null;
     setPrompt('');
     setError(null);
     setStatusMessage(null);
+    setStreamingAssistantState(null);
     setIsDictating(false);
     router.replace({
       pathname: '/ai',
@@ -345,9 +529,12 @@ export function AssistantChatShell({
   }, [router]);
 
   const handleOpenConversation = useCallback((nextConversationId: string) => {
+    activeRunAbortRef.current?.abort();
+    activeRunAbortRef.current = null;
     setError(null);
     setStatusMessage(null);
     setPrompt('');
+    setStreamingAssistantState(null);
     router.replace(`/ai/thread/${nextConversationId}`);
   }, [router]);
 
@@ -539,6 +726,18 @@ export function AssistantChatShell({
                   </View>
                 ) : null}
 
+                {activeConversation?.messagePage?.hasMore ? (
+                  <View className="w-full max-w-3xl items-center">
+                    <AppButton
+                      label={isLoadingOlderMessages ? 'Loading older messages...' : 'Load older messages'}
+                      size="sm"
+                      variant="secondary"
+                      onPress={() => void loadOlderMessages()}
+                      loading={isLoadingOlderMessages}
+                    />
+                  </View>
+                ) : null}
+
                 {activeConversation?.messages.map((turn) => (
                   <View
                     key={turn.id}
@@ -563,6 +762,17 @@ export function AssistantChatShell({
                     </View>
                   </View>
                 ))}
+
+                {isThreadMode && isStreamingRun && streamingAssistantBlocks.length > 0 ? (
+                  <View className="w-full items-start">
+                    <View className="max-w-3xl items-start gap-2">
+                      <Text className="px-1 text-caption uppercase tracking-[0.16em] text-subtle">Assistant</Text>
+                      <View className="rounded-lg bg-[#F8F6F1] px-0 py-0">
+                        <AssistantMessageBlocks blocks={streamingAssistantBlocks} />
+                      </View>
+                    </View>
+                  </View>
+                ) : null}
 
                 {activeConversation && activeConversation.messages.length === 0 ? (
                   <View className="w-full max-w-3xl rounded-md border border-dashed border-border bg-surface-2 px-5 py-5">

--- a/admin/features/assistant/hooks/use-assistant-approve-mutation.ts
+++ b/admin/features/assistant/hooks/use-assistant-approve-mutation.ts
@@ -1,8 +1,22 @@
-import { useMutation } from '@admin/lib/query';
+import { queryKeys, useMutation } from '@admin/lib/query';
 import { assistantService } from '../services/assistant.service';
 
 export function useAssistantApproveMutation() {
   return useMutation({
     mutationFn: (input: { approvalId: string; approve: boolean }) => assistantService.decideApproval(input),
+    invalidateAll: false,
+    invalidateKeys: [queryKeys.assistant.approvals()],
+    invalidatePrefixes: [
+      queryKeys.assistant.conversations(),
+      queryKeys.assistant.history(),
+      queryKeys.orders.sales(),
+      queryKeys.orders.purchase(),
+      queryKeys.products.all(),
+      queryKeys.inventory.stockOnHand(),
+      queryKeys.inventory.movements(),
+      queryKeys.inventory.receipts(),
+      queryKeys.settings.tenant(),
+      queryKeys.dashboard.overview(),
+    ],
   });
 }

--- a/admin/features/assistant/hooks/use-assistant-conversation-query.ts
+++ b/admin/features/assistant/hooks/use-assistant-conversation-query.ts
@@ -6,5 +6,8 @@ export function useAssistantConversationQuery(id: string | undefined, enabled = 
     key: queryKeys.assistant.conversation(id ?? 'unknown'),
     enabled: enabled && Boolean(id),
     queryFn: () => assistantService.getConversation(id ?? ''),
+    manualInvalidationOnly: false,
+    staleTimeMs: 5 * 60 * 1000,
+    gcTimeMs: 30 * 60 * 1000,
   });
 }

--- a/admin/features/assistant/hooks/use-assistant-create-conversation-mutation.ts
+++ b/admin/features/assistant/hooks/use-assistant-create-conversation-mutation.ts
@@ -4,5 +4,6 @@ import { assistantService } from '../services/assistant.service';
 export function useAssistantCreateConversationMutation() {
   return useMutation({
     mutationFn: (input: { title?: string; initialMessage?: string | null }) => assistantService.createConversation(input),
+    invalidateAll: false,
   });
 }

--- a/admin/features/assistant/hooks/use-assistant-decision-mutation.ts
+++ b/admin/features/assistant/hooks/use-assistant-decision-mutation.ts
@@ -1,8 +1,22 @@
-import { useMutation } from '@admin/lib/query';
+import { queryKeys, useMutation } from '@admin/lib/query';
 import { assistantService } from '../services/assistant.service';
 
 export function useAssistantDecisionMutation() {
   return useMutation({
     mutationFn: (input: { workflowId: string; decision: string; note?: string }) => assistantService.decide(input),
+    invalidateAll: false,
+    invalidateKeys: [queryKeys.assistant.approvals()],
+    invalidatePrefixes: [
+      queryKeys.assistant.conversations(),
+      queryKeys.assistant.history(),
+      queryKeys.orders.sales(),
+      queryKeys.orders.purchase(),
+      queryKeys.products.all(),
+      queryKeys.inventory.stockOnHand(),
+      queryKeys.inventory.movements(),
+      queryKeys.inventory.receipts(),
+      queryKeys.settings.tenant(),
+      queryKeys.dashboard.overview(),
+    ],
   });
 }

--- a/admin/features/assistant/hooks/use-assistant-send-message-mutation.ts
+++ b/admin/features/assistant/hooks/use-assistant-send-message-mutation.ts
@@ -4,5 +4,6 @@ import { assistantService } from '../services/assistant.service';
 export function useAssistantSendMessageMutation() {
   return useMutation({
     mutationFn: (input: { conversationId: string; content: string }) => assistantService.sendMessage(input),
+    invalidateAll: false,
   });
 }

--- a/admin/features/assistant/services/assistant-cache.ts
+++ b/admin/features/assistant/services/assistant-cache.ts
@@ -1,0 +1,143 @@
+import type {
+  AssistantConversation,
+  AssistantConversationSummary,
+  AssistantMessage,
+  AssistantMessageBlock,
+  AssistantMessagePage,
+} from '../types/assistant.types';
+
+function dedupeMessages(messages: AssistantMessage[]) {
+  const seen = new Set<string>();
+  const deduped: AssistantMessage[] = [];
+
+  messages.forEach((message) => {
+    if (seen.has(message.id)) return;
+    seen.add(message.id);
+    deduped.push(message);
+  });
+
+  deduped.sort((left, right) => new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime());
+  return deduped;
+}
+
+function messagePreviewFromBlocks(blocks: AssistantMessageBlock[]) {
+  for (const block of blocks) {
+    if (block.type === 'text' && block.content.trim()) return block.content.trim();
+    if (block.type === 'clarification' && block.prompt.trim()) return block.prompt.trim();
+    if (block.type === 'preview' && block.actionType.trim()) return block.actionType.trim();
+    if ((block.type === 'success' || block.type === 'error') && block.message.trim()) return block.message.trim();
+    if ((block.type === 'approval_pending' || block.type === 'approval_result') && block.message.trim()) return block.message.trim();
+  }
+
+  return null;
+}
+
+export function createOptimisticUserMessage(content: string): AssistantMessage {
+  const now = new Date().toISOString();
+  return {
+    id: `optimistic-user-${now}-${Math.random().toString(36).slice(2, 10)}`,
+    role: 'user',
+    createdAt: now,
+    blocks: [{ type: 'text', content }],
+  };
+}
+
+export function createStreamingAssistantMessage(content: string): AssistantMessage {
+  const now = new Date().toISOString();
+  return {
+    id: `streaming-assistant-${now}`,
+    role: 'assistant',
+    createdAt: now,
+    blocks: content.trim() ? [{ type: 'text', content }] : [],
+  };
+}
+
+export function mergeAssistantConversationPage(
+  existing: AssistantConversation | null,
+  incoming: AssistantConversation,
+  mode: 'replace-latest' | 'prepend-older',
+): AssistantConversation {
+  if (!existing) {
+    return incoming;
+  }
+
+  if (mode === 'prepend-older') {
+    return {
+      ...existing,
+      conversation: incoming.conversation,
+      workflow: incoming.workflow,
+      pendingAction: incoming.pendingAction,
+      messagePage: incoming.messagePage,
+      messages: dedupeMessages([...incoming.messages, ...existing.messages]),
+    };
+  }
+
+  const incomingIds = new Set(incoming.messages.map((message) => message.id));
+  const olderMessages = existing.messages.filter((message) => !incomingIds.has(message.id)).filter((message) => {
+    const firstIncoming = incoming.messages[0];
+    if (!firstIncoming) return true;
+    return new Date(message.createdAt).getTime() < new Date(firstIncoming.createdAt).getTime();
+  });
+
+  return {
+    ...existing,
+    conversation: incoming.conversation,
+    workflow: incoming.workflow,
+    pendingAction: incoming.pendingAction,
+    messagePage: incoming.messagePage,
+    messages: dedupeMessages([...olderMessages, ...incoming.messages]),
+  };
+}
+
+export function updateAssistantConversationSummaryCache(
+  existing: AssistantConversationSummary[] | null,
+  conversation: AssistantConversation,
+): AssistantConversationSummary[] {
+  const lastMessage = conversation.messages[conversation.messages.length - 1] ?? null;
+  const lastMessagePreview = lastMessage ? messagePreviewFromBlocks(lastMessage.blocks) : null;
+  const lastRole = lastMessage?.role ?? null;
+
+  const nextItem: AssistantConversationSummary = {
+    id: conversation.conversation.id,
+    title: conversation.conversation.title,
+    createdAt: conversation.conversation.createdAt,
+    updatedAt: conversation.conversation.updatedAt,
+    lastMessagePreview,
+    lastRole,
+  };
+
+  const filtered = (existing ?? []).filter((item) => item.id !== nextItem.id);
+  return [nextItem, ...filtered].sort(
+    (left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime(),
+  );
+}
+
+export function appendAssistantConversationMessage(
+  conversation: AssistantConversation | null,
+  message: AssistantMessage,
+): AssistantConversation | null {
+  if (!conversation) return conversation;
+  return {
+    ...conversation,
+    messages: dedupeMessages([...conversation.messages, message]),
+  };
+}
+
+export function removeAssistantConversationMessage(
+  conversation: AssistantConversation | null,
+  messageId: string,
+): AssistantConversation | null {
+  if (!conversation) return conversation;
+  return {
+    ...conversation,
+    messages: conversation.messages.filter((message) => message.id !== messageId),
+  };
+}
+
+export function emptyMessagePage(): AssistantMessagePage {
+  return {
+    nextCursorCreatedAt: null,
+    nextCursorId: null,
+    hasMore: false,
+  };
+}

--- a/admin/features/assistant/services/assistant.service.ts
+++ b/admin/features/assistant/services/assistant.service.ts
@@ -79,8 +79,19 @@ export const assistantService = {
     );
   },
 
-  getConversation(id: string) {
-    return engineGet<AssistantConversation>(`/api/chat/conversations/${id}`);
+  getConversation(
+    id: string,
+    options?: {
+      messageLimit?: number;
+      beforeCreatedAt?: string | null;
+      beforeId?: string | null;
+    },
+  ) {
+    return engineGet<AssistantConversation>(`/api/chat/conversations/${id}`, {
+      message_limit: options?.messageLimit,
+      before_created_at: options?.beforeCreatedAt ?? undefined,
+      before_id: options?.beforeId ?? undefined,
+    });
   },
 
   createConversation(input: { title?: string; initialMessage?: string | null; attachmentIds?: string[] }) {
@@ -106,6 +117,7 @@ export const assistantService = {
       attachments?: Array<{ dataUrl: string; filename?: string }>;
     },
     onEvent: (event: AssistantRunEvent) => void | Promise<void>,
+    options?: { signal?: AbortSignal },
   ): Promise<{ runId: string | null; conversationId: string | null; workflowId: string | null }> {
     let latestEvent: AssistantRunEvent | null = null;
     await engineStream<AssistantRunEvent, typeof input>(
@@ -115,6 +127,7 @@ export const assistantService = {
         latestEvent = event;
         await onEvent(event);
       },
+      options,
     );
     const finalEvent = latestEvent as AssistantRunEvent | null;
     return {

--- a/admin/features/assistant/types/assistant.types.ts
+++ b/admin/features/assistant/types/assistant.types.ts
@@ -89,6 +89,12 @@ export type AssistantPendingAction = {
   prompt: string;
 };
 
+export type AssistantMessagePage = {
+  nextCursorCreatedAt?: string | null;
+  nextCursorId?: string | null;
+  hasMore: boolean;
+};
+
 export type AssistantConversation = {
   conversation: {
     id: string;
@@ -99,6 +105,7 @@ export type AssistantConversation = {
   workflow?: AssistantWorkflowState | null;
   messages: AssistantMessage[];
   pendingAction?: AssistantPendingAction | null;
+  messagePage?: AssistantMessagePage | null;
 };
 
 export type AssistantDecisionResponse = {

--- a/admin/features/auth/hooks/use-auth-session.tsx
+++ b/admin/features/auth/hooks/use-auth-session.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, createContext, useCallback, useContext, useEffect, useM
 import { Platform } from 'react-native';
 import { openBrowserAsync, WebBrowserPresentationStyle } from 'expo-web-browser';
 import { configureApiClient } from '@admin/lib/api';
+import { queryClient } from '@admin/lib/query';
 import { authService } from '../services/auth.service';
 import { sessionStorage } from '../services/session-storage';
 import type { LoginInput, RegisterBusinessInput } from '../types/auth.types';
@@ -59,6 +60,28 @@ function resolvePortalMode(): PortalMode {
   return 'business';
 }
 
+function buildQueryCacheNamespace({
+  portalMode,
+  principalType,
+  userId,
+  selectedTenantId,
+}: {
+  portalMode: PortalMode;
+  principalType?: PrincipalType | null;
+  userId?: string | null;
+  selectedTenantId?: string | null;
+}) {
+  if (!principalType || !userId) {
+    return `guest:${portalMode}`;
+  }
+
+  if (portalMode === 'platform' || principalType === 'platform_admin') {
+    return `portal:${portalMode}:platform_admin:${userId}`;
+  }
+
+  return `portal:${portalMode}:tenant_user:${userId}:tenant:${selectedTenantId ?? 'none'}`;
+}
+
 async function buildSessionUser(portalMode: PortalMode) {
   if (portalMode === 'platform') {
     const profile = await authService.platformMe();
@@ -104,10 +127,12 @@ export function AuthSessionProvider({ children }: { children: ReactNode }) {
 
   const signOut = useCallback(() => {
     sessionStorage.clear();
+    queryClient.setNamespace(buildQueryCacheNamespace({ portalMode }));
+    void queryClient.clearAll();
     setState({ ...initialState, status: 'signed_out' });
     unauthorizedHandlerRef.current = null;
     configureApiClient({ getAccessToken: () => null, getTenantId: () => null, onUnauthorized: undefined });
-  }, []);
+  }, [portalMode]);
 
   const applyApiContext = useCallback((nextState: SessionState) => {
     configureApiClient({
@@ -153,6 +178,14 @@ export function AuthSessionProvider({ children }: { children: ReactNode }) {
         selectedTenantId: nextSelectedTenantId,
       };
 
+      queryClient.setNamespace(
+        buildQueryCacheNamespace({
+          portalMode,
+          principalType: user.principalType,
+          userId: user.id,
+          selectedTenantId: nextSelectedTenantId,
+        }),
+      );
       setState(nextState);
       applyApiContext(nextState);
     },
@@ -195,6 +228,7 @@ export function AuthSessionProvider({ children }: { children: ReactNode }) {
 
     if (!stored.accessToken || !stored.refreshToken) {
       const signedOut: SessionState = { ...initialState, status: 'signed_out' };
+      queryClient.setNamespace(buildQueryCacheNamespace({ portalMode }));
       setState(signedOut);
       applyApiContext(signedOut);
       return;
@@ -292,6 +326,14 @@ export function AuthSessionProvider({ children }: { children: ReactNode }) {
     if (portalMode !== 'business') return;
     setState((prev) => {
       const nextState = { ...prev, selectedTenantId: tenantId };
+      queryClient.setNamespace(
+        buildQueryCacheNamespace({
+          portalMode,
+          principalType: nextState.user?.principalType,
+          userId: nextState.user?.id,
+          selectedTenantId: tenantId,
+        }),
+      );
       applyApiContext(nextState);
       return nextState;
     });

--- a/admin/features/index.ts
+++ b/admin/features/index.ts
@@ -1,4 +1,4 @@
-export * as aiFeature from './ai';
+export * as aiFeature from './assistant';
 export * as auditFeature from './audit';
 export * as authFeature from './auth';
 export * as dashboardFeature from './dashboard';

--- a/admin/features/orders/services/orders.service.ts
+++ b/admin/features/orders/services/orders.service.ts
@@ -147,10 +147,11 @@ export const ordersService = {
   },
 
   async createSalesOrder(payload: { customerId: string; lines: Array<{ sizeId: string; qty: number; unitPrice: number }> }) {
-    return post<{ id: string }, { customerId: string; lines: Array<{ sizeId: string; qty: number; unitPrice: number }> }>(
+    const created = await post<SalesOrderRow, { customerId: string; lines: Array<{ sizeId: string; qty: number; unitPrice: number }> }>(
       '/sales/invoice',
       payload,
     );
+    return toSalesOrder(created);
   },
 
   async dispatchSalesOrder(id: string, payload: { locationId: string; confirm: boolean }) {
@@ -179,10 +180,11 @@ export const ordersService = {
     expectedDate?: string;
     lines: Array<{ sizeId: string; qty: number; unitCost: number }>;
   }) {
-    return post<
-      { id: string },
+    const created = await post<
+      PurchaseOrderRow,
       { supplierId: string; expectedDate?: string; lines: Array<{ sizeId: string; qty: number; unitCost: number }> }
     >('/purchasing/po', payload);
+    return toPurchaseOrder(created);
   },
 
   async receivePurchaseOrder(

--- a/admin/features/products/types/products.types.ts
+++ b/admin/features/products/types/products.types.ts
@@ -18,7 +18,7 @@ export type ProductInput = {
   inventoryMode?: 'local' | 'global';
   maxBackorderQty?: number | null;
   pickupEnabled?: boolean;
-  categoryId?: string;
+  categoryId?: string | null;
   status?: Extract<Status, 'active' | 'inactive'>;
 };
 

--- a/admin/lib/api/client.ts
+++ b/admin/lib/api/client.ts
@@ -20,6 +20,40 @@ function createIdempotencyKey() {
   return `${now}-${randA}-${randB}`;
 }
 
+function createAbortContext(timeoutMs: number, signal?: AbortSignal) {
+  const timeoutController = new AbortController();
+  const requestController = new AbortController();
+  const timeoutId = setTimeout(() => timeoutController.abort(), timeoutMs);
+
+  const abortFromTimeout = () => {
+    requestController.abort();
+  };
+  const abortFromSignal = () => {
+    requestController.abort();
+  };
+
+  timeoutController.signal.addEventListener('abort', abortFromTimeout, { once: true });
+
+  if (signal) {
+    if (signal.aborted) {
+      abortFromSignal();
+    } else {
+      signal.addEventListener('abort', abortFromSignal, { once: true });
+    }
+  }
+
+  return {
+    signal: requestController.signal,
+    didTimeout: () => timeoutController.signal.aborted,
+    wasAbortedByCaller: () => Boolean(signal?.aborted) && !timeoutController.signal.aborted,
+    cleanup: () => {
+      clearTimeout(timeoutId);
+      timeoutController.signal.removeEventListener('abort', abortFromTimeout);
+      signal?.removeEventListener('abort', abortFromSignal);
+    },
+  };
+}
+
 function buildUrl(path: string, query?: QueryParams, baseUrl?: string) {
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
   const url = new URL(`${baseUrl ?? API_BASE_URL}${normalizedPath}`);
@@ -108,10 +142,7 @@ export async function request<TResponse, TBody = unknown>({
   idempotencyKey,
   signal,
 }: ApiRequestOptions<TBody>): Promise<TResponse> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
-
-  const mergedSignal = signal ?? controller.signal;
+  const abortContext = createAbortContext(API_TIMEOUT_MS, signal);
   const isWriteMethod = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method.toUpperCase());
   const resolvedIdempotencyKey = idempotencyKey ?? (isWriteMethod ? createIdempotencyKey() : undefined);
   const hasBody = body !== undefined && body !== null;
@@ -127,7 +158,7 @@ export async function request<TResponse, TBody = unknown>({
       method,
       headers: requestHeaders,
       body: hasBody ? (isFormDataBody ? (body as BodyInit) : JSON.stringify(body)) : undefined,
-      signal: mergedSignal,
+      signal: abortContext.signal,
     });
   }
 
@@ -171,12 +202,15 @@ export async function request<TResponse, TBody = unknown>({
     }
 
     if (error instanceof Error && error.name === 'AbortError') {
+      if (abortContext.wasAbortedByCaller()) {
+        throw new ApiError('Request aborted', 499, 'REQUEST_ABORTED');
+      }
       throw new ApiError('Request timed out', 408, 'REQUEST_TIMEOUT');
     }
 
     throw new ApiError('Network request failed', 0, 'NETWORK_ERROR', error);
   } finally {
-    clearTimeout(timeoutId);
+    abortContext.cleanup();
   }
 }
 
@@ -226,9 +260,7 @@ export async function streamRequest<TEvent, TBody = unknown>({
 }: ApiRequestOptions<TBody> & {
   onEvent: (event: TEvent) => void | Promise<void>;
 }) {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS * 4);
-  const mergedSignal = signal ?? controller.signal;
+  const abortContext = createAbortContext(API_TIMEOUT_MS * 4, signal);
   const hasBody = body !== undefined && body !== null;
   const isFormDataBody = hasBody && typeof FormData !== 'undefined' && body instanceof FormData;
   const resolvedIdempotencyKey = idempotencyKey ?? createIdempotencyKey();
@@ -241,7 +273,7 @@ export async function streamRequest<TEvent, TBody = unknown>({
       method,
       headers: requestHeaders,
       body: hasBody ? (isFormDataBody ? (body as BodyInit) : JSON.stringify(body)) : undefined,
-      signal: mergedSignal,
+      signal: abortContext.signal,
     });
 
     if (!response.ok) {
@@ -285,10 +317,13 @@ export async function streamRequest<TEvent, TBody = unknown>({
   } catch (error) {
     if (error instanceof ApiError) throw error;
     if (error instanceof Error && error.name === 'AbortError') {
+      if (abortContext.wasAbortedByCaller()) {
+        throw new ApiError('Request aborted', 499, 'REQUEST_ABORTED');
+      }
       throw new ApiError('Request timed out', 408, 'REQUEST_TIMEOUT');
     }
     throw new ApiError('Network request failed', 0, 'NETWORK_ERROR', error);
   } finally {
-    clearTimeout(timeoutId);
+    abortContext.cleanup();
   }
 }

--- a/admin/lib/engine-client/client.ts
+++ b/admin/lib/engine-client/client.ts
@@ -1,11 +1,13 @@
 import { request, streamRequest } from '@admin/lib/api';
+import type { QueryParams } from '@admin/lib/api';
 import { ENGINE_BASE_URL } from './config';
 
-export function engineGet<TResponse>(path: string) {
+export function engineGet<TResponse>(path: string, query?: QueryParams) {
   return request<TResponse>({
     method: 'GET',
     path,
     baseUrl: ENGINE_BASE_URL,
+    query,
   });
 }
 
@@ -31,6 +33,7 @@ export function engineStream<TEvent, TBody = unknown>(
   path: string,
   body: TBody,
   onEvent: (event: TEvent) => void | Promise<void>,
+  options?: { signal?: AbortSignal },
 ) {
   return streamRequest<TEvent, TBody>({
     method: 'POST',
@@ -38,5 +41,6 @@ export function engineStream<TEvent, TBody = unknown>(
     body,
     baseUrl: ENGINE_BASE_URL,
     onEvent,
+    signal: options?.signal,
   });
 }

--- a/admin/lib/query/index.ts
+++ b/admin/lib/query/index.ts
@@ -1,4 +1,6 @@
+export * from './query-client';
 export * from './query-keys';
+export * from './query-cache-storage';
 export * from './types';
 export * from './use-mutation';
 export * from './use-query';

--- a/admin/lib/query/query-cache-storage.ts
+++ b/admin/lib/query/query-cache-storage.ts
@@ -1,0 +1,118 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Platform } from 'react-native';
+import type { QueryPersistenceEnvelope } from './types';
+
+const QUERY_CACHE_INDEX_KEY = 'admin.query-cache.index.v1';
+const QUERY_CACHE_NAMESPACE_PREFIX = 'admin.query-cache.namespace.v1:';
+
+function hasBrowserStorage() {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+function getNamespaceStorageKey(namespace: string) {
+  return `${QUERY_CACHE_NAMESPACE_PREFIX}${namespace}`;
+}
+
+async function readRaw(key: string): Promise<string | null> {
+  if (hasBrowserStorage()) {
+    return window.localStorage.getItem(key);
+  }
+
+  if (Platform.OS !== 'web') {
+    return AsyncStorage.getItem(key);
+  }
+
+  return null;
+}
+
+async function writeRaw(key: string, value: string) {
+  if (hasBrowserStorage()) {
+    window.localStorage.setItem(key, value);
+    return;
+  }
+
+  if (Platform.OS !== 'web') {
+    await AsyncStorage.setItem(key, value);
+  }
+}
+
+async function removeRaw(key: string) {
+  if (hasBrowserStorage()) {
+    window.localStorage.removeItem(key);
+    return;
+  }
+
+  if (Platform.OS !== 'web') {
+    await AsyncStorage.removeItem(key);
+  }
+}
+
+async function readIndex(): Promise<string[]> {
+  const raw = await readRaw(QUERY_CACHE_INDEX_KEY);
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((value): value is string => typeof value === 'string' && value.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+async function writeIndex(namespaces: string[]) {
+  await writeRaw(QUERY_CACHE_INDEX_KEY, JSON.stringify(Array.from(new Set(namespaces)).sort()));
+}
+
+function parseEnvelope(raw: string | null): QueryPersistenceEnvelope | null {
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<QueryPersistenceEnvelope> | null;
+    if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.entries)) {
+      return null;
+    }
+
+    return {
+      version: 1,
+      entries: parsed.entries.filter(
+        (entry): entry is QueryPersistenceEnvelope['entries'][number] =>
+          typeof entry === 'object' &&
+          entry !== null &&
+          Array.isArray(entry.key) &&
+          'data' in entry &&
+          ('updatedAt' in entry ? typeof entry.updatedAt === 'number' || entry.updatedAt === null : true),
+      ),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export const queryCacheStorage = {
+  async readNamespace(namespace: string): Promise<QueryPersistenceEnvelope | null> {
+    return parseEnvelope(await readRaw(getNamespaceStorageKey(namespace)));
+  },
+
+  async writeNamespace(namespace: string, envelope: QueryPersistenceEnvelope) {
+    await writeRaw(getNamespaceStorageKey(namespace), JSON.stringify(envelope));
+    const namespaces = await readIndex();
+    if (!namespaces.includes(namespace)) {
+      await writeIndex([...namespaces, namespace]);
+    }
+  },
+
+  async deleteNamespace(namespace: string) {
+    await removeRaw(getNamespaceStorageKey(namespace));
+    const namespaces = await readIndex();
+    if (namespaces.includes(namespace)) {
+      await writeIndex(namespaces.filter((value) => value !== namespace));
+    }
+  },
+
+  async clearAllNamespaces() {
+    const namespaces = await readIndex();
+    await Promise.all(namespaces.map((namespace) => removeRaw(getNamespaceStorageKey(namespace))));
+    await removeRaw(QUERY_CACHE_INDEX_KEY);
+  },
+};

--- a/admin/lib/query/query-client.ts
+++ b/admin/lib/query/query-client.ts
@@ -1,0 +1,401 @@
+import { ApiError } from '@admin/lib/api';
+import { queryCacheStorage } from './query-cache-storage';
+import type { QueryCacheEntry, QueryKey, QueryPersistenceEnvelope, QueryState } from './types';
+
+type QueryListener = () => void;
+type NamespaceListener = (namespace: string) => void;
+
+type FetchQueryOptions<TData> = {
+  namespace: string;
+  key: QueryKey;
+  queryFn: () => Promise<TData>;
+  retry: number;
+  retryDelayMs: number;
+  persist: boolean;
+  force?: boolean;
+};
+
+type NamespaceStore = {
+  entries: Map<string, QueryCacheEntry<unknown>>;
+  listeners: Map<string, Set<QueryListener>>;
+  inflight: Map<string, Promise<unknown>>;
+  hydrated: boolean;
+  hydrating: Promise<void> | null;
+  persistTimer: ReturnType<typeof setTimeout> | null;
+};
+
+const PERSIST_DEBOUNCE_MS = 150;
+const DEFAULT_NAMESPACE = 'guest:unknown';
+
+function createNamespaceStore(): NamespaceStore {
+  return {
+    entries: new Map(),
+    listeners: new Map(),
+    inflight: new Map(),
+    hydrated: false,
+    hydrating: null,
+    persistTimer: null,
+  };
+}
+
+function createEmptyEntry<TData>(key: QueryKey, persist: boolean): QueryCacheEntry<TData> {
+  return {
+    key,
+    data: null,
+    error: null,
+    status: 'idle',
+    isLoading: false,
+    isFetching: false,
+    updatedAt: null,
+    invalidated: false,
+    persist,
+  };
+}
+
+function serializeKey(key: QueryKey) {
+  return JSON.stringify(key);
+}
+
+function keysMatchPrefix(key: QueryKey, prefix: QueryKey) {
+  if (prefix.length > key.length) return false;
+  return prefix.every((value, index) => key[index] === value);
+}
+
+class QueryClient {
+  private namespace = DEFAULT_NAMESPACE;
+  private stores = new Map<string, NamespaceStore>();
+  private namespaceListeners = new Set<NamespaceListener>();
+
+  getNamespace() {
+    return this.namespace;
+  }
+
+  setNamespace(namespace: string | null | undefined) {
+    const nextNamespace = namespace && namespace.trim() ? namespace : DEFAULT_NAMESPACE;
+    if (nextNamespace === this.namespace) return;
+    this.namespace = nextNamespace;
+    this.namespaceListeners.forEach((listener) => listener(nextNamespace));
+  }
+
+  subscribeToNamespaceChanges(listener: NamespaceListener) {
+    this.namespaceListeners.add(listener);
+    return () => {
+      this.namespaceListeners.delete(listener);
+    };
+  }
+
+  private getNamespaceStore(namespace: string) {
+    const existing = this.stores.get(namespace);
+    if (existing) return existing;
+
+    const created = createNamespaceStore();
+    this.stores.set(namespace, created);
+    return created;
+  }
+
+  private getEntry<TData>(namespace: string, key: QueryKey): QueryCacheEntry<TData> | null {
+    const store = this.getNamespaceStore(namespace);
+    const entry = store.entries.get(serializeKey(key));
+    return (entry as QueryCacheEntry<TData> | undefined) ?? null;
+  }
+
+  private setEntry<TData>(namespace: string, entry: QueryCacheEntry<TData>) {
+    const store = this.getNamespaceStore(namespace);
+    store.entries.set(serializeKey(entry.key), entry as QueryCacheEntry<unknown>);
+    this.notify(namespace, entry.key);
+    this.schedulePersist(namespace);
+  }
+
+  private notify(namespace: string, key: QueryKey) {
+    const store = this.getNamespaceStore(namespace);
+    const listeners = store.listeners.get(serializeKey(key));
+    listeners?.forEach((listener) => listener());
+  }
+
+  subscribe(namespace: string, key: QueryKey, listener: QueryListener) {
+    const store = this.getNamespaceStore(namespace);
+    const hash = serializeKey(key);
+    const listeners = store.listeners.get(hash) ?? new Set<QueryListener>();
+    listeners.add(listener);
+    store.listeners.set(hash, listeners);
+    return () => {
+      const existing = store.listeners.get(hash);
+      if (!existing) return;
+      existing.delete(listener);
+      if (existing.size === 0) {
+        store.listeners.delete(hash);
+      }
+    };
+  }
+
+  private schedulePersist(namespace: string) {
+    const store = this.getNamespaceStore(namespace);
+    if (store.persistTimer) {
+      clearTimeout(store.persistTimer);
+    }
+    store.persistTimer = setTimeout(() => {
+      store.persistTimer = null;
+      void this.persistNamespace(namespace);
+    }, PERSIST_DEBOUNCE_MS);
+  }
+
+  private buildPersistenceEnvelope(namespace: string): QueryPersistenceEnvelope {
+    const store = this.getNamespaceStore(namespace);
+    const entries = Array.from(store.entries.values())
+      .filter((entry) => entry.persist && entry.status === 'success' && entry.data !== null)
+      .map((entry) => ({
+        key: entry.key,
+        data: entry.data,
+        updatedAt: entry.updatedAt,
+      }));
+
+    return {
+      version: 1,
+      entries,
+    };
+  }
+
+  private async persistNamespace(namespace: string) {
+    const envelope = this.buildPersistenceEnvelope(namespace);
+    if (envelope.entries.length === 0) {
+      await queryCacheStorage.deleteNamespace(namespace);
+      return;
+    }
+
+    await queryCacheStorage.writeNamespace(namespace, envelope);
+  }
+
+  async ensureHydrated(namespace: string) {
+    const store = this.getNamespaceStore(namespace);
+    if (store.hydrated) return;
+    if (store.hydrating) {
+      await store.hydrating;
+      return;
+    }
+
+    store.hydrating = (async () => {
+      const envelope = await queryCacheStorage.readNamespace(namespace);
+      if (envelope?.entries?.length) {
+        envelope.entries.forEach((entry) => {
+          store.entries.set(
+            serializeKey(entry.key),
+            {
+              key: entry.key,
+              data: entry.data,
+              error: null,
+              status: 'success',
+              isLoading: false,
+              isFetching: false,
+              updatedAt: entry.updatedAt,
+              invalidated: false,
+              persist: true,
+            },
+          );
+        });
+      }
+      store.hydrated = true;
+      store.hydrating = null;
+    })();
+
+    await store.hydrating;
+  }
+
+  getQueryData<TData>(key: QueryKey, namespace = this.namespace): TData | null {
+    return (this.getEntry<TData>(namespace, key)?.data as TData | null) ?? null;
+  }
+
+  getQueryState<TData>(key: QueryKey, namespace = this.namespace): QueryState<TData> | null {
+    const entry = this.getEntry<TData>(namespace, key);
+    if (!entry) return null;
+    return {
+      data: entry.data,
+      error: entry.error,
+      status: entry.status,
+      isLoading: entry.isLoading,
+      isFetching: entry.isFetching,
+      updatedAt: entry.updatedAt,
+    };
+  }
+
+  hasQueryData(key: QueryKey, namespace = this.namespace) {
+    const entry = this.getEntry(namespace, key);
+    return Boolean(entry && entry.data !== null);
+  }
+
+  isInvalidated(key: QueryKey, namespace = this.namespace) {
+    return Boolean(this.getEntry(namespace, key)?.invalidated);
+  }
+
+  setQueryData<TData>(
+    key: QueryKey,
+    updater: TData | null | ((current: TData | null) => TData | null),
+    options?: { namespace?: string; persist?: boolean },
+  ) {
+    const namespace = options?.namespace ?? this.namespace;
+    const current = this.getEntry<TData>(namespace, key);
+    const persist = options?.persist ?? current?.persist ?? true;
+    const nextData = typeof updater === 'function' ? (updater as (current: TData | null) => TData | null)(current?.data ?? null) : updater;
+    const nextEntry: QueryCacheEntry<TData> = {
+      ...(current ?? createEmptyEntry<TData>(key, persist)),
+      key,
+      data: nextData,
+      error: null,
+      status: nextData === null ? 'idle' : 'success',
+      isLoading: false,
+      isFetching: false,
+      updatedAt: nextData === null ? current?.updatedAt ?? null : Date.now(),
+      invalidated: false,
+      persist,
+    };
+    this.setEntry(namespace, nextEntry);
+  }
+
+  removeQueries(prefix?: QueryKey, namespace = this.namespace) {
+    const store = this.getNamespaceStore(namespace);
+    const keysToRemove = Array.from(store.entries.values())
+      .filter((entry) => !prefix || keysMatchPrefix(entry.key, prefix))
+      .map((entry) => entry.key);
+
+    keysToRemove.forEach((key) => {
+      store.entries.delete(serializeKey(key));
+      this.notify(namespace, key);
+    });
+
+    this.schedulePersist(namespace);
+  }
+
+  invalidateQuery(key: QueryKey, namespace = this.namespace) {
+    const entry = this.getEntry(namespace, key);
+    if (!entry) return;
+    this.setEntry(namespace, {
+      ...entry,
+      invalidated: true,
+    });
+  }
+
+  invalidateQueries(prefix?: QueryKey, namespace = this.namespace) {
+    const store = this.getNamespaceStore(namespace);
+    store.entries.forEach((entry) => {
+      if (prefix && !keysMatchPrefix(entry.key, prefix)) return;
+      this.setEntry(namespace, {
+        ...entry,
+        invalidated: true,
+      });
+    });
+  }
+
+  invalidateAll(namespace = this.namespace) {
+    this.invalidateQueries(undefined, namespace);
+  }
+
+  async clearNamespace(namespace = this.namespace) {
+    const store = this.getNamespaceStore(namespace);
+    if (store.persistTimer) {
+      clearTimeout(store.persistTimer);
+      store.persistTimer = null;
+    }
+    store.entries.clear();
+    store.listeners.forEach((listeners) => listeners.forEach((listener) => listener()));
+    await queryCacheStorage.deleteNamespace(namespace);
+  }
+
+  async clearAll() {
+    this.stores.forEach((store) => {
+      if (store.persistTimer) {
+        clearTimeout(store.persistTimer);
+        store.persistTimer = null;
+      }
+      store.entries.clear();
+      store.listeners.forEach((listeners) => listeners.forEach((listener) => listener()));
+    });
+    await queryCacheStorage.clearAllNamespaces();
+  }
+
+  private async runFetchWithRetry<TData>(options: FetchQueryOptions<TData>) {
+    let lastError: ApiError | null = null;
+
+    for (let attempt = 0; attempt <= options.retry; attempt += 1) {
+      try {
+        return await options.queryFn();
+      } catch (error) {
+        lastError = error instanceof ApiError ? error : new ApiError('Unknown query error', 0, 'QUERY_ERROR', error);
+        if (attempt < options.retry) {
+          await new Promise((resolve) => setTimeout(resolve, options.retryDelayMs));
+        }
+      }
+    }
+
+    throw lastError ?? new ApiError('Unknown query error', 0, 'QUERY_ERROR');
+  }
+
+  async fetchQuery<TData>({
+    namespace,
+    key,
+    queryFn,
+    retry,
+    retryDelayMs,
+    persist,
+    force = false,
+  }: FetchQueryOptions<TData>) {
+    const store = this.getNamespaceStore(namespace);
+    const hash = serializeKey(key);
+    const current = this.getEntry<TData>(namespace, key);
+
+    if (!force) {
+      const inflight = store.inflight.get(hash);
+      if (inflight) {
+        return inflight as Promise<TData>;
+      }
+    }
+
+    this.setEntry(namespace, {
+      ...(current ?? createEmptyEntry<TData>(key, persist)),
+      key,
+      persist,
+      status: current?.data === null || current?.data === undefined ? 'loading' : current?.status ?? 'success',
+      isLoading: current?.data === null || current?.data === undefined,
+      isFetching: true,
+      error: current?.error ?? null,
+      invalidated: false,
+    });
+
+    const inflight = this.runFetchWithRetry({ namespace, key, queryFn, retry, retryDelayMs, persist, force })
+      .then((data) => {
+        this.setEntry(namespace, {
+          key,
+          data,
+          error: null,
+          status: 'success',
+          isLoading: false,
+          isFetching: false,
+          updatedAt: Date.now(),
+          invalidated: false,
+          persist,
+        });
+        return data;
+      })
+      .catch((error: unknown) => {
+        const apiError = error instanceof ApiError ? error : new ApiError('Unknown query error', 0, 'QUERY_ERROR', error);
+        const previous = this.getEntry<TData>(namespace, key);
+        this.setEntry(namespace, {
+          ...(previous ?? createEmptyEntry<TData>(key, persist)),
+          key,
+          error: apiError,
+          status: previous?.data !== null && previous?.data !== undefined ? 'success' : 'error',
+          isLoading: false,
+          isFetching: false,
+          invalidated: false,
+          persist,
+        });
+        throw apiError;
+      })
+      .finally(() => {
+        store.inflight.delete(hash);
+      });
+
+    store.inflight.set(hash, inflight);
+    return inflight;
+  }
+}
+
+export const queryClient = new QueryClient();

--- a/admin/lib/query/types.ts
+++ b/admin/lib/query/types.ts
@@ -10,6 +10,7 @@ export type QueryState<TData> = {
   status: QueryStatus;
   isLoading: boolean;
   isFetching: boolean;
+  updatedAt: number | null;
 };
 
 export type MutationState<TResult> = {
@@ -17,4 +18,34 @@ export type MutationState<TResult> = {
   error: ApiError | null;
   isPending: boolean;
   isSuccess: boolean;
+};
+
+export type QueryCacheEntry<TData> = QueryState<TData> & {
+  key: QueryKey;
+  invalidated: boolean;
+  persist: boolean;
+};
+
+export type UseQueryOptions<TData> = {
+  key: QueryKey;
+  queryFn: () => Promise<TData>;
+  enabled?: boolean;
+  initialData?: TData | null;
+  retry?: number;
+  retryDelayMs?: number;
+  persist?: boolean;
+  manualInvalidationOnly?: boolean;
+  staleTimeMs?: number;
+  gcTimeMs?: number;
+};
+
+export type QueryPersistenceEntry = {
+  key: QueryKey;
+  data: unknown;
+  updatedAt: number | null;
+};
+
+export type QueryPersistenceEnvelope = {
+  version: 1;
+  entries: QueryPersistenceEntry[];
 };

--- a/admin/lib/query/use-mutation.ts
+++ b/admin/lib/query/use-mutation.ts
@@ -1,14 +1,26 @@
 import { useCallback, useState } from 'react';
 import { ApiError } from '@admin/lib/api';
 import type { MutationState } from './types';
+import { queryClient } from './query-client';
+import type { QueryKey } from './types';
 
 type UseMutationOptions<TPayload, TResult> = {
   mutationFn: (payload: TPayload) => Promise<TResult>;
   onSuccess?: (result: TResult, payload: TPayload) => void;
   onError?: (error: ApiError, payload: TPayload) => void;
+  invalidateAll?: boolean;
+  invalidateKeys?: QueryKey[] | ((result: TResult, payload: TPayload) => QueryKey[]);
+  invalidatePrefixes?: QueryKey[] | ((result: TResult, payload: TPayload) => QueryKey[]);
 };
 
-export function useMutation<TPayload, TResult>({ mutationFn, onSuccess, onError }: UseMutationOptions<TPayload, TResult>) {
+export function useMutation<TPayload, TResult>({
+  mutationFn,
+  onSuccess,
+  onError,
+  invalidateAll = true,
+  invalidateKeys,
+  invalidatePrefixes,
+}: UseMutationOptions<TPayload, TResult>) {
   const [state, setState] = useState<MutationState<TResult>>({
     data: null,
     error: null,
@@ -23,6 +35,17 @@ export function useMutation<TPayload, TResult>({ mutationFn, onSuccess, onError 
       try {
         const result = await mutationFn(payload);
         setState({ data: result, error: null, isPending: false, isSuccess: true });
+
+        const resolvedInvalidateKeys = typeof invalidateKeys === 'function' ? invalidateKeys(result, payload) : invalidateKeys ?? [];
+        const resolvedInvalidatePrefixes =
+          typeof invalidatePrefixes === 'function' ? invalidatePrefixes(result, payload) : invalidatePrefixes ?? [];
+
+        if (invalidateAll) {
+          queryClient.invalidateAll();
+        }
+        resolvedInvalidateKeys.forEach((key) => queryClient.invalidateQuery(key));
+        resolvedInvalidatePrefixes.forEach((prefix) => queryClient.invalidateQueries(prefix));
+
         onSuccess?.(result, payload);
         return result;
       } catch (error) {
@@ -32,7 +55,7 @@ export function useMutation<TPayload, TResult>({ mutationFn, onSuccess, onError 
         throw apiError;
       }
     },
-    [mutationFn, onError, onSuccess],
+    [invalidateAll, invalidateKeys, invalidatePrefixes, mutationFn, onError, onSuccess],
   );
 
   const reset = useCallback(() => {

--- a/admin/lib/query/use-query.ts
+++ b/admin/lib/query/use-query.ts
@@ -1,15 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ApiError } from '@admin/lib/api';
-import type { QueryKey, QueryState } from './types';
-
-type UseQueryOptions<TData> = {
-  key: QueryKey;
-  queryFn: () => Promise<TData>;
-  enabled?: boolean;
-  initialData?: TData | null;
-  retry?: number;
-  retryDelayMs?: number;
-};
+import type { QueryKey, QueryState, UseQueryOptions } from './types';
+import { queryClient } from './query-client';
 
 export function useQuery<TData>({
   key,
@@ -18,66 +9,186 @@ export function useQuery<TData>({
   initialData = null,
   retry = 1,
   retryDelayMs = 250,
+  persist = true,
+  manualInvalidationOnly = true,
+  staleTimeMs = 0,
+  gcTimeMs,
 }: UseQueryOptions<TData>) {
   const queryFnRef = useRef(queryFn);
-  const [state, setState] = useState<QueryState<TData>>({
-    data: initialData,
-    error: null,
-    status: enabled ? 'loading' : 'idle',
-    isLoading: enabled,
-    isFetching: enabled,
-  });
-
   const stableKey = useMemo(() => JSON.stringify(key), [key]);
+  const normalizedKey = useMemo<QueryKey>(() => JSON.parse(stableKey) as QueryKey, [stableKey]);
+
+  const getCachedState = useCallback((namespace: string): QueryState<TData> | null => {
+    const cached = queryClient.getQueryState<TData>(normalizedKey, namespace);
+    if (!cached) {
+      return null;
+    }
+
+    if (
+      gcTimeMs !== undefined &&
+      gcTimeMs >= 0 &&
+      cached.updatedAt !== null &&
+      Date.now() - cached.updatedAt > gcTimeMs
+    ) {
+      queryClient.removeQueries(normalizedKey, namespace);
+      return null;
+    }
+
+    return cached;
+  }, [gcTimeMs, normalizedKey]);
+
+  const isFresh = useCallback((state: QueryState<TData> | null) => {
+    if (!state || staleTimeMs <= 0 || state.updatedAt === null) {
+      return false;
+    }
+    return Date.now() - state.updatedAt <= staleTimeMs;
+  }, [staleTimeMs]);
+
+  const [state, setState] = useState<QueryState<TData>>(() => {
+    const namespace = queryClient.getNamespace();
+    const cached = getCachedState(namespace);
+    if (cached) {
+      return cached;
+    }
+    return {
+      data: initialData,
+      error: null,
+      status: enabled && initialData === null ? 'loading' : initialData === null ? 'idle' : 'success',
+      isLoading: enabled && initialData === null,
+      isFetching: false,
+      updatedAt: initialData === null ? null : Date.now(),
+    };
+  });
+  const [activeNamespace, setActiveNamespace] = useState(() => queryClient.getNamespace());
 
   useEffect(() => {
     queryFnRef.current = queryFn;
   }, [queryFn]);
 
-  const runQuery = useCallback(async () => {
+  const syncFromCache = useCallback((namespace: string) => {
+    const cached = getCachedState(namespace);
+    if (cached) {
+      setState(cached);
+      return cached;
+    }
+
+    const fallbackState: QueryState<TData> = {
+      data: initialData,
+      error: null,
+      status: enabled && initialData === null ? 'loading' : initialData === null ? 'idle' : 'success',
+      isLoading: enabled && initialData === null,
+      isFetching: false,
+      updatedAt: initialData === null ? null : Date.now(),
+    };
+    setState(fallbackState);
+    return fallbackState;
+  }, [enabled, getCachedState, initialData]);
+
+  const runQuery = useCallback(async (force = true) => {
+    const namespace = queryClient.getNamespace();
+    setActiveNamespace(namespace);
+
     if (!enabled) {
-      setState((prev) => ({ ...prev, status: 'idle', isLoading: false, isFetching: false }));
+      const cachedState = getCachedState(namespace);
+      if (cachedState) {
+        setState({ ...cachedState, isLoading: false, isFetching: false });
+      } else {
+        setState((prev) => ({ ...prev, status: 'idle', isLoading: false, isFetching: false }));
+      }
       return;
     }
 
-    setState((prev) => ({
-      ...prev,
-      isLoading: prev.data === null,
-      isFetching: true,
-      status: prev.data === null ? 'loading' : prev.status,
-    }));
-
-    let lastError: ApiError | null = null;
-    for (let attempt = 0; attempt <= retry; attempt += 1) {
-      try {
-        const data = await queryFnRef.current();
-        setState({ data, error: null, status: 'success', isLoading: false, isFetching: false });
-        return;
-      } catch (error) {
-        lastError = error instanceof ApiError ? error : new ApiError('Unknown query error', 0, 'QUERY_ERROR', error);
-        if (attempt < retry) {
-          await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
-        }
-      }
-    }
-    setState((prev) => ({
-      ...prev,
-      error: lastError ?? new ApiError('Unknown query error', 0, 'QUERY_ERROR'),
-      status: 'error',
-      isLoading: false,
-      isFetching: false,
-    }));
-  }, [enabled, retry, retryDelayMs]);
+    await queryClient.fetchQuery<TData>({
+      namespace,
+      key: normalizedKey,
+      queryFn: () => queryFnRef.current(),
+      retry,
+      retryDelayMs,
+      persist,
+      force,
+    });
+  }, [enabled, getCachedState, normalizedKey, persist, retry, retryDelayMs]);
 
   useEffect(() => {
-    void runQuery();
-  }, [stableKey, runQuery]);
+    let cancelled = false;
+    let unsubscribeEntry: () => void = () => undefined;
+
+    const attachEntrySubscription = (namespace: string) => {
+      unsubscribeEntry();
+      unsubscribeEntry = queryClient.subscribe(namespace, normalizedKey, () => {
+        if (cancelled) return;
+        syncFromCache(namespace);
+
+        if (enabled && queryClient.isInvalidated(normalizedKey, namespace)) {
+          void queryClient.fetchQuery<TData>({
+            namespace,
+            key: normalizedKey,
+            queryFn: () => queryFnRef.current(),
+            retry,
+            retryDelayMs,
+            persist,
+            force: false,
+          }).catch(() => undefined);
+        }
+      });
+    };
+
+    const prepareNamespace = async (namespace: string) => {
+      setActiveNamespace(namespace);
+      attachEntrySubscription(namespace);
+      await queryClient.ensureHydrated(namespace);
+      if (cancelled) return;
+
+      const cached = getCachedState(namespace);
+      if (!cached && initialData !== null) {
+        queryClient.setQueryData<TData>(normalizedKey, initialData, { namespace, persist });
+      } else {
+        syncFromCache(namespace);
+      }
+
+      const shouldFetch =
+        enabled &&
+        (
+          !cached ||
+          queryClient.isInvalidated(normalizedKey, namespace) ||
+          (!manualInvalidationOnly && !isFresh(cached))
+        );
+
+      if (shouldFetch) {
+        void queryClient.fetchQuery<TData>({
+          namespace,
+          key: normalizedKey,
+          queryFn: () => queryFnRef.current(),
+          retry,
+          retryDelayMs,
+          persist,
+          force: false,
+        }).catch(() => undefined);
+      } else {
+        syncFromCache(namespace);
+      }
+    };
+
+    const namespace = queryClient.getNamespace();
+    void prepareNamespace(namespace);
+
+    const unsubscribeNamespace = queryClient.subscribeToNamespaceChanges((nextNamespace) => {
+      if (cancelled) return;
+      void prepareNamespace(nextNamespace);
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribeEntry();
+      unsubscribeNamespace();
+    };
+  }, [enabled, getCachedState, initialData, isFresh, manualInvalidationOnly, normalizedKey, persist, retry, retryDelayMs, stableKey, syncFromCache]);
 
   return {
     ...state,
-    refetch: runQuery,
+    refetch: () => runQuery(true),
     setData: (nextData: TData | null) => {
-      setState((prev) => ({ ...prev, data: nextData }));
+      queryClient.setQueryData<TData>(normalizedKey, nextData, { namespace: activeNamespace, persist });
     },
   };
 }

--- a/backend/migrations/010_dispatched_location.ts
+++ b/backend/migrations/010_dispatched_location.ts
@@ -1,0 +1,16 @@
+/* eslint-disable */
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumns('invoices', {
+    dispatched_location_id: {
+      type: 'uuid',
+      references: 'locations',
+      onDelete: 'set null',
+    },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumns('invoices', ['dispatched_location_id']);
+}

--- a/backend/migrations/011_backfill_sales_read.ts
+++ b/backend/migrations/011_backfill_sales_read.ts
@@ -1,0 +1,20 @@
+/* eslint-disable */
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`
+    UPDATE roles
+    SET permissions = array_append(permissions, 'sales.read')
+    WHERE permissions @> ARRAY['sales.write']::text[]
+      AND NOT permissions @> ARRAY['sales.read']::text[];
+  `);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`
+    UPDATE roles
+    SET permissions = array_remove(permissions, 'sales.read')
+    WHERE permissions @> ARRAY['sales.write']::text[]
+      AND permissions @> ARRAY['sales.read']::text[];
+  `);
+}

--- a/backend/src/middlewares/auth.ts
+++ b/backend/src/middlewares/auth.ts
@@ -168,7 +168,11 @@ export function requireTenantPermission(permission: string) {
     );
     if (roleRes.rowCount === 0) return res.status(403).json({ message: 'Role not found' });
     const permissions: string[] = roleRes.rows[0].permissions ?? [];
-    if (!permissions.includes(permission)) return res.status(403).json({ message: 'Forbidden' });
+    const canReadFromWrite =
+      permission.endsWith('.read') && permissions.includes(permission.replace(/\.read$/, '.write'));
+    if (!permissions.includes(permission) && !canReadFromWrite) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
     next();
   };
 }

--- a/backend/src/modules/auth/service.ts
+++ b/backend/src/modules/auth/service.ts
@@ -44,6 +44,7 @@ const ALL_TENANT_PERMISSIONS = [
   'master.write',
   'purchasing.read',
   'purchasing.write',
+  'sales.read',
   'sales.write',
   'audit.read',
   'chat.use',

--- a/backend/src/modules/products/service.ts
+++ b/backend/src/modules/products/service.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { randomUUID } from 'node:crypto';
+import type { QueryResultRow } from 'pg';
 import { z } from 'zod';
 import { S3_BUCKET, S3_PUBLIC_BASE_URL, S3_REGION } from '@backend/config/env.js';
 import { pool, query } from '@backend/db/pool.js';
@@ -118,14 +119,54 @@ function buildS3ObjectUrl(key: string) {
   return `https://${S3_BUCKET}.s3.${S3_REGION}.amazonaws.com/${key}`;
 }
 
+function parsePagination(input: Request['query']) {
+  const page = Math.max(1, Number(input.page ?? 1) || 1);
+  const pageSize = Math.min(100, Math.max(1, Number(input.pageSize ?? 20) || 20));
+  return { page, pageSize };
+}
+
+type UpdateFieldSpec = {
+  column: string;
+  value: unknown;
+};
+
+function buildDynamicUpdate<T extends QueryResultRow>(
+  table: string,
+  idColumn: string,
+  idValue: string,
+  tenantId: string,
+  fields: UpdateFieldSpec[],
+) {
+  if (fields.length === 0) {
+    return query<T>(`SELECT * FROM ${table} WHERE ${idColumn} = $1 AND tenant_id = $2`, [idValue, tenantId]);
+  }
+
+  const assignments = fields.map((field, index) => `${field.column} = $${index + 1}`);
+  const params = fields.map((field) => field.value);
+  params.push(idValue, tenantId);
+
+  return query<T>(
+    `UPDATE ${table}
+     SET ${assignments.join(', ')}, updated_at = NOW()
+     WHERE ${idColumn} = $${fields.length + 1} AND tenant_id = $${fields.length + 2}
+     RETURNING *`,
+    params,
+  );
+}
+
 export async function listProducts(req: Request, res: Response) {
-  const q = typeof req.query.q === 'string' ? req.query.q.trim() : null;
+  const { page, pageSize } = parsePagination(req.query);
+  const offset = (page - 1) * pageSize;
+  const search = typeof req.query.search === 'string' ? req.query.search.trim() : null;
+  const q = search || (typeof req.query.q === 'string' ? req.query.q.trim() : null);
   const color = typeof req.query.color === 'string' ? req.query.color.trim() : null;
   const category = typeof req.query.category === 'string' ? req.query.category.trim() : null;
+  const categoryId = typeof req.query.categoryId === 'string' ? req.query.categoryId.trim() : null;
   const brand = typeof req.query.brand === 'string' ? req.query.brand.trim() : null;
+  const status = typeof req.query.status === 'string' ? req.query.status.trim() : null;
 
   const conditions: string[] = ['p.tenant_id = $1'];
-  const params: (string | null)[] = [req.user!.tenantId];
+  const params: Array<string | number | null> = [req.user!.tenantId];
   let idx = 2;
 
   if (q) {
@@ -143,18 +184,46 @@ export async function listProducts(req: Request, res: Response) {
     params.push(`%${category}%`);
     idx++;
   }
+  if (categoryId) {
+    conditions.push(`p.category_id::text = $${idx}`);
+    params.push(categoryId);
+    idx++;
+  }
   if (brand) {
     conditions.push(`p.brand ILIKE $${idx}`);
     params.push(`%${brand}%`);
     idx++;
   }
+  if (status) {
+    conditions.push(`p.status::text = $${idx}`);
+    params.push(status);
+    idx++;
+  }
+
+  const totalRes = await query<{ total: number }>(
+    `SELECT COUNT(*)::int AS total
+     FROM products p
+     WHERE ${conditions.join(' AND ')}`,
+    params,
+  );
 
   const rows = await query(
-    `SELECT p.id, p.style_code, p.name, p.category, p.brand, p.base_price, p.status, p.created_at, p.updated_at
-     FROM products p WHERE ${conditions.join(' AND ')} ORDER BY p.updated_at DESC LIMIT 30`,
-    params
+    `SELECT p.id, p.tenant_id, p.style_code, p.name, p.category, p.brand, p.base_price, p.status, p.created_at, p.updated_at
+     FROM products p
+     WHERE ${conditions.join(' AND ')}
+     ORDER BY p.updated_at DESC
+     LIMIT $${idx} OFFSET $${idx + 1}`,
+    [...params, pageSize, offset],
   );
-  res.json(rows.rows);
+
+  res.json({
+    items: rows.rows,
+    pagination: {
+      page,
+      pageSize,
+      total: Number(totalRes.rows[0]?.total ?? rows.rows.length),
+    },
+  });
 }
 
 export async function createProduct(req: Request, res: Response) {
@@ -415,38 +484,21 @@ export async function updateProduct(req: Request, res: Response) {
   const parsed = productSchema.partial().safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ message: 'Invalid payload' });
   const p = parsed.data;
-  const result = await query(
-    `UPDATE products SET
-       style_code = COALESCE($1, style_code),
-       name = COALESCE($2, name),
-       category = COALESCE($3, category),
-       brand = COALESCE($4, brand),
-       base_price = COALESCE($5, base_price),
-       price_visible = COALESCE($6, price_visible),
-       inventory_mode = COALESCE($7, inventory_mode),
-       max_backorder_qty = COALESCE($8, max_backorder_qty),
-       pickup_enabled = COALESCE($9, pickup_enabled),
-       category_id = COALESCE($10, category_id),
-       status = COALESCE($11, status),
-       updated_at = NOW()
-     WHERE id = $12 AND tenant_id = $13
-     RETURNING *`,
-    [
-      p.styleCode ?? null,
-      p.name ?? null,
-      p.category ?? null,
-      p.brand ?? null,
-      p.basePrice ?? null,
-      p.priceVisible ?? null,
-      p.inventoryMode ?? null,
-      p.maxBackorderQty ?? null,
-      p.pickupEnabled ?? null,
-      p.categoryId ?? null,
-      p.status ?? null,
-      req.params.id,
-      req.user!.tenantId,
-    ]
-  );
+  const body = req.body ?? {};
+  const fields: UpdateFieldSpec[] = [];
+  if ('styleCode' in body) fields.push({ column: 'style_code', value: p.styleCode });
+  if ('name' in body) fields.push({ column: 'name', value: p.name });
+  if ('category' in body) fields.push({ column: 'category', value: p.category });
+  if ('brand' in body) fields.push({ column: 'brand', value: p.brand });
+  if ('basePrice' in body) fields.push({ column: 'base_price', value: p.basePrice });
+  if ('priceVisible' in body) fields.push({ column: 'price_visible', value: p.priceVisible });
+  if ('inventoryMode' in body) fields.push({ column: 'inventory_mode', value: p.inventoryMode });
+  if ('maxBackorderQty' in body) fields.push({ column: 'max_backorder_qty', value: p.maxBackorderQty ?? null });
+  if ('pickupEnabled' in body) fields.push({ column: 'pickup_enabled', value: p.pickupEnabled });
+  if ('categoryId' in body) fields.push({ column: 'category_id', value: p.categoryId ?? null });
+  if ('status' in body) fields.push({ column: 'status', value: p.status });
+
+  const result = await buildDynamicUpdate('products', 'id', req.params.id, req.user!.tenantId, fields);
   if (result.rowCount === 0) return res.status(404).json({ message: 'Not found' });
   res.json(result.rows[0]);
 }
@@ -498,18 +550,15 @@ export async function updateSku(req: Request, res: Response) {
   const parsed = skuSchema.partial().safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ message: 'Invalid payload' });
   const s = parsed.data;
-  const result = await query(
-    `UPDATE skus SET
-       color_name = COALESCE($1, color_name),
-       color_code = COALESCE($2, color_code),
-       sku_code = COALESCE($3, sku_code),
-       price_override = COALESCE($4, price_override),
-       status = COALESCE($5, status),
-       updated_at = NOW()
-     WHERE id = $6 AND tenant_id = $7
-     RETURNING *`,
-    [s.colorName ?? null, s.colorCode ?? null, s.skuCode ?? null, s.priceOverride ?? null, s.status ?? null, req.params.skuId, req.user!.tenantId]
-  );
+  const body = req.body ?? {};
+  const fields: UpdateFieldSpec[] = [];
+  if ('colorName' in body) fields.push({ column: 'color_name', value: s.colorName });
+  if ('colorCode' in body) fields.push({ column: 'color_code', value: s.colorCode ?? null });
+  if ('skuCode' in body) fields.push({ column: 'sku_code', value: s.skuCode });
+  if ('priceOverride' in body) fields.push({ column: 'price_override', value: s.priceOverride ?? null });
+  if ('status' in body) fields.push({ column: 'status', value: s.status });
+
+  const result = await buildDynamicUpdate('skus', 'id', req.params.skuId, req.user!.tenantId, fields);
   if (result.rowCount === 0) return res.status(404).json({ message: 'Not found' });
   res.json(result.rows[0]);
 }
@@ -537,19 +586,16 @@ export async function updateSkuSize(req: Request, res: Response) {
   const parsed = sizeSchema.partial().safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ message: 'Invalid payload' });
   const s = parsed.data;
-  const result = await query(
-    `UPDATE sku_sizes SET
-       size_label = COALESCE($1, size_label),
-       barcode = COALESCE($2, barcode),
-       unit_of_measure = COALESCE($3, unit_of_measure),
-       pack_size = COALESCE($4, pack_size),
-       price_override = COALESCE($5, price_override),
-       status = COALESCE($6, status),
-       updated_at = NOW()
-     WHERE id = $7 AND tenant_id = $8
-     RETURNING *`,
-    [s.sizeLabel ?? null, s.barcode ?? null, s.unitOfMeasure ?? null, s.packSize ?? null, s.priceOverride ?? null, s.status ?? null, req.params.sizeId, req.user!.tenantId]
-  );
+  const body = req.body ?? {};
+  const fields: UpdateFieldSpec[] = [];
+  if ('sizeLabel' in body) fields.push({ column: 'size_label', value: s.sizeLabel });
+  if ('barcode' in body) fields.push({ column: 'barcode', value: s.barcode });
+  if ('unitOfMeasure' in body) fields.push({ column: 'unit_of_measure', value: s.unitOfMeasure });
+  if ('packSize' in body) fields.push({ column: 'pack_size', value: s.packSize });
+  if ('priceOverride' in body) fields.push({ column: 'price_override', value: s.priceOverride ?? null });
+  if ('status' in body) fields.push({ column: 'status', value: s.status });
+
+  const result = await buildDynamicUpdate('sku_sizes', 'id', req.params.sizeId, req.user!.tenantId, fields);
   if (result.rowCount === 0) return res.status(404).json({ message: 'Not found' });
   res.json(result.rows[0]);
 }

--- a/backend/src/modules/purchasing/routes.ts
+++ b/backend/src/modules/purchasing/routes.ts
@@ -20,5 +20,6 @@ r.post('/po', requirePermission('purchasing.write'), requireTenantWriteAccess({ 
 r.patch('/po/:id', requirePermission('purchasing.write'), requireTenantWriteAccess({ feature: 'purchasing' }), idem, ctrl.updatePO);
 r.post('/po/:id/receive', requirePermission('purchasing.write'), requireTenantWriteAccess({ feature: 'purchasing' }), idem, ctrl.receivePO);
 r.post('/po/:id/close', requirePermission('purchasing.write'), requireTenantWriteAccess({ feature: 'purchasing' }), idem, ctrl.closePO);
+r.post('/po/:id/cancel', requirePermission('purchasing.write'), requireTenantWriteAccess({ feature: 'purchasing' }), idem, ctrl.cancelPO);
 
 export default r;

--- a/backend/src/modules/purchasing/service.ts
+++ b/backend/src/modules/purchasing/service.ts
@@ -14,16 +14,284 @@ const poSchema = z.object({
   lines: z.array(lineSchema).min(1),
 });
 
+const lineRefSchema = z
+  .object({
+    lineId: z.string().uuid().optional(),
+    sizeId: z.string().uuid().optional(),
+    skuCode: z.string().trim().min(1).optional(),
+    sizeLabel: z.string().trim().min(1).optional(),
+  })
+  .refine(
+    (value) => Boolean(value.lineId || value.sizeId || (value.skuCode && value.sizeLabel)),
+    'lineRef must include lineId, sizeId, or skuCode + sizeLabel',
+  );
+
+const poLineValuesSchema = z.object({
+  sizeId: z.string().uuid(),
+  qty: z.number().int().positive(),
+  unitCost: z.number().int().nonnegative(),
+});
+
+const poLineOpSchema = z
+  .object({
+    op: z.enum(['add', 'replace', 'change_qty', 'change_cost', 'remove']),
+    lineRef: lineRefSchema.optional(),
+    values: poLineValuesSchema.optional(),
+    qty: z.number().int().positive().optional(),
+    unitCost: z.number().int().nonnegative().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.op === 'add') {
+      if (!value.values) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'add requires values' });
+      }
+      return;
+    }
+    if (!value.lineRef) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: `${value.op} requires lineRef` });
+    }
+    if (value.op === 'replace' && !value.values) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'replace requires values' });
+    }
+    if (value.op === 'change_qty' && value.qty == null) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'change_qty requires qty' });
+    }
+    if (value.op === 'change_cost' && value.unitCost == null) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'change_cost requires unitCost' });
+    }
+  });
+
+const poHeaderPatchSchema = z.object({
+  supplierId: z.string().uuid().optional(),
+  expectedDate: z.string().datetime().nullable().optional(),
+});
+
+const poUpdateSchema = z
+  .object({
+    supplierId: z.string().uuid().optional(),
+    expectedDate: z.string().datetime().nullable().optional(),
+    lines: z.array(lineSchema).min(1).optional(),
+    headerPatch: poHeaderPatchSchema.optional(),
+    lineOps: z.array(poLineOpSchema).min(1).optional(),
+  })
+  .refine(
+    (value) =>
+      value.supplierId !== undefined ||
+      value.expectedDate !== undefined ||
+      value.lines !== undefined ||
+      value.headerPatch !== undefined ||
+      value.lineOps !== undefined,
+    'At least one purchase order change is required',
+  );
+
 const receiveSchema = z.object({
   locationId: z.string().uuid(),
   lines: z.array(lineSchema).min(1),
   confirm: z.boolean().default(false),
 });
 
+const confirmSchema = z.object({
+  confirm: z.literal(true),
+});
+
+type Queryable = {
+  query: typeof pool.query;
+};
+
+type PODetailRow = {
+  id: string;
+  supplier_id: string;
+  supplier_name: string;
+  status: string;
+  expected_date: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type POLineDetailRow = {
+  id: string;
+  size_id: string;
+  qty: number | string;
+  unit_cost: number | string;
+  sku_code: string;
+  size_label: string;
+  qty_received: number | string;
+};
+
+type POLineRef = z.infer<typeof lineRefSchema>;
+type POLineOp = z.infer<typeof poLineOpSchema>;
+
+function hasOwn(payload: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(payload, key);
+}
+
 function parsePagination(input: Request['query']) {
   const page = Math.max(1, Number(input.page ?? 1) || 1);
   const pageSize = Math.min(100, Math.max(1, Number(input.pageSize ?? 20) || 20));
   return { page, pageSize };
+}
+
+async function getPOById(client: Queryable, tenantId: string, poId: string) {
+  const poRes = await client.query<PODetailRow>(
+    `SELECT
+       po.id,
+       po.supplier_id,
+       s.name AS supplier_name,
+       po.status,
+       po.expected_date,
+       po.created_at,
+       po.updated_at
+     FROM purchase_orders po
+     JOIN suppliers s ON s.id = po.supplier_id
+     WHERE po.id = $1 AND po.tenant_id = $2`,
+    [poId, tenantId],
+  );
+  if (poRes.rowCount === 0) {
+    return null;
+  }
+
+  const linesRes = await client.query<POLineDetailRow>(
+    `SELECT
+       pol.id,
+       pol.size_id,
+       pol.qty,
+       pol.unit_cost,
+       s.sku_code,
+       sz.size_label,
+       COALESCE(SUM(rl.qty), 0)::int AS qty_received
+     FROM purchase_order_lines pol
+     JOIN sku_sizes sz ON sz.id = pol.size_id
+     JOIN skus s ON s.id = sz.sku_id
+     LEFT JOIN receipts r ON r.po_id = pol.po_id AND r.tenant_id = pol.tenant_id
+     LEFT JOIN receipt_lines rl ON rl.receipt_id = r.id AND rl.size_id = pol.size_id AND rl.tenant_id = pol.tenant_id
+     WHERE pol.po_id = $1 AND pol.tenant_id = $2
+     GROUP BY pol.id, pol.size_id, pol.qty, pol.unit_cost, s.sku_code, sz.size_label
+     ORDER BY pol.id`,
+    [poId, tenantId],
+  );
+
+  const lines = linesRes.rows.map((line: POLineDetailRow) => ({
+    id: line.id,
+    skuId: line.size_id,
+    sku: `${line.sku_code}-${line.size_label}`,
+    qtyOrdered: Number(line.qty ?? 0),
+    qtyReceived: Number(line.qty_received ?? 0),
+    unitCost: Number(line.unit_cost ?? 0),
+  }));
+
+  const base = poRes.rows[0];
+  return {
+    id: base.id,
+    number: `PO-${String(base.id).slice(0, 8).toUpperCase()}`,
+    supplierId: base.supplier_id,
+    supplierName: base.supplier_name,
+    status: base.status,
+    currency: 'USD',
+    lines,
+    lineCount: lines.length,
+    orderedAt: base.created_at,
+    expectedAt: base.expected_date,
+    createdAt: base.created_at,
+    updatedAt: base.updated_at,
+    totalCost: lines.reduce((sum: number, line) => sum + line.qtyOrdered * line.unitCost, 0),
+  };
+}
+
+async function resolvePOLine(client: Queryable, tenantId: string, poId: string, lineRef: POLineRef) {
+  if (lineRef.lineId) {
+    const lineRes = await client.query<{ id: string }>(
+      `SELECT id
+       FROM purchase_order_lines
+       WHERE id = $1 AND po_id = $2 AND tenant_id = $3`,
+      [lineRef.lineId, poId, tenantId],
+    );
+    if (lineRes.rowCount === 1) {
+      return lineRes.rows[0];
+    }
+    throw new Error('Purchase order line not found');
+  }
+
+  if (lineRef.sizeId) {
+    const lineRes = await client.query<{ id: string }>(
+      `SELECT id
+       FROM purchase_order_lines
+       WHERE po_id = $1 AND tenant_id = $2 AND size_id = $3`,
+      [poId, tenantId, lineRef.sizeId],
+    );
+    if (lineRes.rowCount === 1) {
+      return lineRes.rows[0];
+    }
+    throw new Error('Purchase order line not found');
+  }
+
+  const skuCode = String(lineRef.skuCode || '').trim().toUpperCase();
+  const sizeLabel = String(lineRef.sizeLabel || '').trim().toUpperCase();
+  const lineRes = await client.query<{ id: string }>(
+    `SELECT pol.id
+     FROM purchase_order_lines pol
+     JOIN sku_sizes sz ON sz.id = pol.size_id
+     JOIN skus s ON s.id = sz.sku_id
+     WHERE pol.po_id = $1
+       AND pol.tenant_id = $2
+       AND UPPER(s.sku_code) = $3
+       AND UPPER(sz.size_label) = $4`,
+    [poId, tenantId, skuCode, sizeLabel],
+  );
+  if (lineRes.rowCount === 1) {
+    return lineRes.rows[0];
+  }
+  throw new Error('Purchase order line not found');
+}
+
+async function applyPOLineOps(client: Queryable, tenantId: string, poId: string, lineOps: POLineOp[]) {
+  for (const lineOp of lineOps) {
+    if (lineOp.op === 'add') {
+      const values = lineOp.values!;
+      await client.query(
+        `INSERT INTO purchase_order_lines (tenant_id, po_id, size_id, qty, unit_cost)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [tenantId, poId, values.sizeId, values.qty, values.unitCost],
+      );
+      continue;
+    }
+
+    const resolvedLine = await resolvePOLine(client, tenantId, poId, lineOp.lineRef!);
+    if (lineOp.op === 'replace') {
+      const values = lineOp.values!;
+      await client.query(
+        `UPDATE purchase_order_lines
+         SET size_id = $1, qty = $2, unit_cost = $3
+         WHERE id = $4 AND tenant_id = $5`,
+        [values.sizeId, values.qty, values.unitCost, resolvedLine.id, tenantId],
+      );
+      continue;
+    }
+    if (lineOp.op === 'change_qty') {
+      await client.query(
+        `UPDATE purchase_order_lines
+         SET qty = $1
+         WHERE id = $2 AND tenant_id = $3`,
+        [lineOp.qty, resolvedLine.id, tenantId],
+      );
+      continue;
+    }
+    if (lineOp.op === 'change_cost') {
+      await client.query(
+        `UPDATE purchase_order_lines
+         SET unit_cost = $1
+         WHERE id = $2 AND tenant_id = $3`,
+        [lineOp.unitCost, resolvedLine.id, tenantId],
+      );
+      continue;
+    }
+    if (lineOp.op === 'remove') {
+      await client.query(
+        `DELETE FROM purchase_order_lines
+         WHERE id = $1 AND tenant_id = $2`,
+        [resolvedLine.id, tenantId],
+      );
+    }
+  }
 }
 
 export async function listPOs(req: Request, res: Response) {
@@ -90,67 +358,11 @@ export async function listPOs(req: Request, res: Response) {
 }
 
 export async function getPO(req: Request, res: Response) {
-  const poRes = await pool.query(
-    `SELECT
-       po.id,
-       po.supplier_id,
-       s.name AS supplier_name,
-       po.status,
-       po.expected_date,
-       po.created_at,
-       po.updated_at
-     FROM purchase_orders po
-     JOIN suppliers s ON s.id = po.supplier_id
-     WHERE po.id = $1 AND po.tenant_id = $2`,
-    [req.params.id, req.user!.tenantId],
-  );
-  if (poRes.rowCount === 0) {
+  const po = await getPOById(pool, req.user!.tenantId, req.params.id);
+  if (!po) {
     return res.status(404).json({ message: 'PO not found' });
   }
-
-  const linesRes = await pool.query(
-    `SELECT
-       pol.id,
-       pol.size_id,
-       pol.qty,
-       pol.unit_cost,
-       s.sku_code,
-       sz.size_label,
-       COALESCE(SUM(rl.qty), 0)::int AS qty_received
-     FROM purchase_order_lines pol
-     JOIN sku_sizes sz ON sz.id = pol.size_id
-     JOIN skus s ON s.id = sz.sku_id
-     LEFT JOIN receipts r ON r.po_id = pol.po_id AND r.tenant_id = pol.tenant_id
-     LEFT JOIN receipt_lines rl ON rl.receipt_id = r.id AND rl.size_id = pol.size_id AND rl.tenant_id = pol.tenant_id
-     WHERE pol.po_id = $1 AND pol.tenant_id = $2
-     GROUP BY pol.id, pol.size_id, pol.qty, pol.unit_cost, s.sku_code, sz.size_label
-     ORDER BY pol.id`,
-    [req.params.id, req.user!.tenantId],
-  );
-
-  const lines = linesRes.rows.map((line) => ({
-    id: line.id,
-    skuId: line.size_id,
-    sku: `${line.sku_code}-${line.size_label}`,
-    qtyOrdered: Number(line.qty ?? 0),
-    qtyReceived: Number(line.qty_received ?? 0),
-    unitCost: Number(line.unit_cost ?? 0),
-  }));
-
-  const base = poRes.rows[0];
-  return res.json({
-    id: base.id,
-    number: `PO-${String(base.id).slice(0, 8).toUpperCase()}`,
-    supplierId: base.supplier_id,
-    supplierName: base.supplier_name,
-    status: base.status,
-    currency: 'USD',
-    lines,
-    orderedAt: base.created_at,
-    expectedAt: base.expected_date,
-    createdAt: base.created_at,
-    updatedAt: base.updated_at,
-  });
+  return res.json(po);
 }
 
 export async function createPO(req: Request, res: Response) {
@@ -182,7 +394,16 @@ export async function receivePO(req: Request, res: Response) {
 
 export async function closePO(req: Request, res: Response) {
   try {
-    const result = await executeClosePO(req.user!.id, req.user!.tenantId, req.params.id);
+    const result = await executeClosePO(req.user!.id, req.user!.tenantId, req.params.id, req.body);
+    res.json(result);
+  } catch (err: any) {
+    res.status(400).json({ message: err.message ?? 'Failed' });
+  }
+}
+
+export async function cancelPO(req: Request, res: Response) {
+  try {
+    const result = await executeCancelPO(req.user!.id, req.user!.tenantId, req.params.id, req.body);
     res.json(result);
   } catch (err: any) {
     res.status(400).json({ message: err.message ?? 'Failed' });
@@ -199,18 +420,20 @@ export async function executeCreatePO(actorId: string, tenantId: string, payload
     const poRes = await client.query(
       `INSERT INTO purchase_orders (tenant_id, supplier_id, status, expected_date, created_by)
        VALUES ($1,$2,'draft',$3,$4) RETURNING id`,
-      [tenantId, body.supplierId, body.expectedDate ?? null, actorId]
+      [tenantId, body.supplierId, body.expectedDate ?? null, actorId],
     );
     const poId = poRes.rows[0].id;
     for (const line of body.lines) {
       await client.query(
         `INSERT INTO purchase_order_lines (tenant_id, po_id, size_id, qty, unit_cost)
          VALUES ($1,$2,$3,$4,$5)`,
-        [tenantId, poId, line.sizeId, line.qty, line.unitCost]
+        [tenantId, poId, line.sizeId, line.qty, line.unitCost],
       );
     }
     await client.query('COMMIT');
-    return { id: poId };
+    const created = await getPOById(client, tenantId, poId);
+    if (!created) throw new Error('Failed to load created purchase order');
+    return created;
   } catch (err) {
     await client.query('ROLLBACK');
     throw err;
@@ -220,16 +443,34 @@ export async function executeCreatePO(actorId: string, tenantId: string, payload
 }
 
 export async function executeUpdatePO(actorId: string, tenantId: string, poId: string, payload: any) {
-  const parsed = poSchema.partial().safeParse(payload);
+  const parsed = poUpdateSchema.safeParse(payload);
   if (!parsed.success) throw new Error('Invalid payload');
   const body = parsed.data;
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
+    const headerPatch = {
+      ...(body.headerPatch ?? {}),
+      ...(hasOwn(body, 'supplierId') ? { supplierId: body.supplierId } : {}),
+      ...(hasOwn(body, 'expectedDate') ? { expectedDate: body.expectedDate ?? null } : {}),
+    };
+    const setClauses: string[] = ['updated_at = NOW()'];
+    const values: Array<string | null> = [];
+    if (hasOwn(headerPatch, 'supplierId')) {
+      values.push(headerPatch.supplierId ?? null);
+      setClauses.push(`supplier_id = $${values.length}`);
+    }
+    if (hasOwn(headerPatch, 'expectedDate')) {
+      values.push(headerPatch.expectedDate ?? null);
+      setClauses.push(`expected_date = $${values.length}`);
+    }
+    values.push(poId, tenantId);
     const poRes = await client.query(
-      `UPDATE purchase_orders SET supplier_id = COALESCE($1,supplier_id), expected_date = COALESCE($2,expected_date), updated_at = NOW()
-       WHERE id = $3 AND tenant_id = $4 AND status = 'draft' RETURNING id`,
-      [body.supplierId ?? null, body.expectedDate ?? null, poId, tenantId]
+      `UPDATE purchase_orders
+       SET ${setClauses.join(', ')}
+       WHERE id = $${values.length - 1} AND tenant_id = $${values.length} AND status = 'draft'
+       RETURNING id`,
+      values,
     );
     if (poRes.rowCount === 0) throw new Error('PO not found or not editable');
     if (body.lines) {
@@ -242,8 +483,13 @@ export async function executeUpdatePO(actorId: string, tenantId: string, poId: s
         );
       }
     }
+    if (body.lineOps) {
+      await applyPOLineOps(client, tenantId, poId, body.lineOps);
+    }
     await client.query('COMMIT');
-    return { id: poId };
+    const updated = await getPOById(client, tenantId, poId);
+    if (!updated) throw new Error('Failed to load updated purchase order');
+    return updated;
   } catch (err) {
     await client.query('ROLLBACK');
     throw err;
@@ -262,10 +508,14 @@ export async function executeReceivePO(actorId: string, tenantId: string, poId: 
   try {
     await client.query('BEGIN');
     const poRes = await client.query(
-      `SELECT id FROM purchase_orders WHERE id = $1 AND tenant_id = $2`,
-      [poId, tenantId]
+      `SELECT id
+       FROM purchase_orders
+       WHERE id = $1
+         AND tenant_id = $2
+         AND status NOT IN ('closed', 'cancelled')`,
+      [poId, tenantId],
     );
-    if (poRes.rowCount === 0) throw new Error('PO not found');
+    if (poRes.rowCount === 0) throw new Error('PO not found or not open for receiving');
 
     const receiptRes = await client.query(
       `INSERT INTO receipts (tenant_id, po_id, location_id, status, created_by)
@@ -300,10 +550,26 @@ export async function executeReceivePO(actorId: string, tenantId: string, poId: 
   }
 }
 
-export async function executeClosePO(actorId: string, tenantId: string, poId: string) {
+export async function executeClosePO(actorId: string, tenantId: string, poId: string, payload: any) {
+  const parsed = confirmSchema.safeParse(payload);
+  if (!parsed.success) throw new Error('Confirmation required');
+
   await pool.query(
     `UPDATE purchase_orders SET status = 'closed', updated_at = NOW() WHERE id = $1 AND tenant_id = $2`,
-    [poId, tenantId]
+    [poId, tenantId],
   );
   return { id: poId, status: 'closed' };
+}
+
+export async function executeCancelPO(actorId: string, tenantId: string, poId: string, payload: any) {
+  const parsed = confirmSchema.safeParse(payload);
+  if (!parsed.success) throw new Error('Confirmation required');
+
+  await pool.query(
+    `UPDATE purchase_orders
+     SET status = 'cancelled', updated_at = NOW()
+     WHERE id = $1 AND tenant_id = $2 AND status NOT IN ('cancelled', 'closed')`,
+    [poId, tenantId],
+  );
+  return { id: poId, status: 'cancelled' };
 }

--- a/backend/src/modules/sales/routes.ts
+++ b/backend/src/modules/sales/routes.ts
@@ -14,8 +14,8 @@ const r = Router();
 r.use(authGuard, requireTenantUser, requireTenantFeatureAccess('sales'));
 const idem = idempotencyGuard((req) => req.user?.tenantId ?? null);
 
-r.get('/invoice', requirePermission('sales.write'), ctrl.listInvoices);
-r.get('/invoice/:id', requirePermission('sales.write'), ctrl.getInvoice);
+r.get('/invoice', requirePermission('sales.read'), ctrl.listInvoices);
+r.get('/invoice/:id', requirePermission('sales.read'), ctrl.getInvoice);
 r.post('/invoice', requirePermission('sales.write'), requireTenantWriteAccess({ feature: 'sales' }), idem, ctrl.createInvoice);
 r.patch('/invoice/:id', requirePermission('sales.write'), requireTenantWriteAccess({ feature: 'sales' }), idem, ctrl.updateInvoice);
 r.post('/invoice/:id/dispatch', requirePermission('sales.write'), requireTenantWriteAccess({ feature: 'sales' }), idem, ctrl.dispatchInvoice);

--- a/backend/src/modules/sales/service.ts
+++ b/backend/src/modules/sales/service.ts
@@ -13,15 +13,290 @@ const invoiceSchema = z.object({
   lines: z.array(lineSchema).min(1),
 });
 
+const lineRefSchema = z
+  .object({
+    lineId: z.string().uuid().optional(),
+    sizeId: z.string().uuid().optional(),
+    skuCode: z.string().trim().min(1).optional(),
+    sizeLabel: z.string().trim().min(1).optional(),
+  })
+  .refine(
+    (value) => Boolean(value.lineId || value.sizeId || (value.skuCode && value.sizeLabel)),
+    'lineRef must include lineId, sizeId, or skuCode + sizeLabel',
+  );
+
+const invoiceLineValuesSchema = z.object({
+  sizeId: z.string().uuid(),
+  qty: z.number().int().positive(),
+  unitPrice: z.number().int().nonnegative(),
+});
+
+const invoiceLineOpSchema = z
+  .object({
+    op: z.enum(['add', 'replace', 'change_qty', 'change_price', 'remove']),
+    lineRef: lineRefSchema.optional(),
+    values: invoiceLineValuesSchema.optional(),
+    qty: z.number().int().positive().optional(),
+    unitPrice: z.number().int().nonnegative().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.op === 'add') {
+      if (!value.values) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'add requires values' });
+      }
+      return;
+    }
+    if (!value.lineRef) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: `${value.op} requires lineRef` });
+    }
+    if (value.op === 'replace' && !value.values) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'replace requires values' });
+    }
+    if (value.op === 'change_qty' && value.qty == null) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'change_qty requires qty' });
+    }
+    if (value.op === 'change_price' && value.unitPrice == null) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'change_price requires unitPrice' });
+    }
+  });
+
+const invoiceHeaderPatchSchema = z.object({
+  customerId: z.string().uuid().optional(),
+});
+
+const invoiceUpdateSchema = z
+  .object({
+    customerId: z.string().uuid().optional(),
+    lines: z.array(lineSchema).min(1).optional(),
+    headerPatch: invoiceHeaderPatchSchema.optional(),
+    lineOps: z.array(invoiceLineOpSchema).min(1).optional(),
+  })
+  .refine(
+    (value) =>
+      value.customerId !== undefined ||
+      value.lines !== undefined ||
+      value.headerPatch !== undefined ||
+      value.lineOps !== undefined,
+    'At least one sales order change is required',
+  );
+
 const dispatchSchema = z.object({
   locationId: z.string().uuid(),
   confirm: z.boolean().default(false),
 });
 
+const confirmSchema = z.object({
+  confirm: z.literal(true),
+});
+
+type Queryable = {
+  query: typeof pool.query;
+};
+
+type InvoiceDetailRow = {
+  id: string;
+  customer_id: string;
+  customer_name: string;
+  status: string;
+  total: number | string;
+  created_at: string;
+  updated_at: string;
+};
+
+type InvoiceLineDetailRow = {
+  id: string;
+  size_id: string;
+  qty: number | string;
+  unit_price: number | string;
+  sku_code: string;
+  size_label: string;
+};
+
+type InvoiceLineRef = z.infer<typeof lineRefSchema>;
+type InvoiceLineOp = z.infer<typeof invoiceLineOpSchema>;
+
+function hasOwn(payload: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(payload, key);
+}
+
 function parsePagination(input: Request['query']) {
   const page = Math.max(1, Number(input.page ?? 1) || 1);
   const pageSize = Math.min(100, Math.max(1, Number(input.pageSize ?? 20) || 20));
   return { page, pageSize };
+}
+
+async function getInvoiceById(client: Queryable, tenantId: string, invoiceId: string) {
+  const invoiceRes = await client.query<InvoiceDetailRow>(
+    `SELECT
+       i.id,
+       i.customer_id,
+       c.name AS customer_name,
+       i.status,
+       i.total,
+       i.created_at,
+       i.updated_at
+     FROM invoices i
+     JOIN customers c ON c.id = i.customer_id
+     WHERE i.id = $1 AND i.tenant_id = $2`,
+    [invoiceId, tenantId],
+  );
+  if (invoiceRes.rowCount === 0) {
+    return null;
+  }
+
+  const linesRes = await client.query<InvoiceLineDetailRow>(
+    `SELECT
+       il.id,
+       il.size_id,
+       il.qty,
+       il.unit_price,
+       s.sku_code,
+       sz.size_label
+     FROM invoice_lines il
+     JOIN sku_sizes sz ON sz.id = il.size_id
+     JOIN skus s ON s.id = sz.sku_id
+     WHERE il.invoice_id = $1 AND il.tenant_id = $2
+     ORDER BY il.id`,
+    [invoiceId, tenantId],
+  );
+
+  const lines = linesRes.rows.map((line: InvoiceLineDetailRow) => ({
+    id: line.id,
+    skuId: line.size_id,
+    sku: `${line.sku_code}-${line.size_label}`,
+    qty: Number(line.qty ?? 0),
+    unitPrice: Number(line.unit_price ?? 0),
+  }));
+
+  const base = invoiceRes.rows[0];
+  const subtotal = lines.reduce((sum: number, line) => sum + line.qty * line.unitPrice, 0);
+
+  return {
+    id: base.id,
+    number: `SO-${String(base.id).slice(0, 8).toUpperCase()}`,
+    customerId: base.customer_id,
+    customerName: base.customer_name,
+    status: base.status,
+    currency: 'USD',
+    lines,
+    lineCount: lines.length,
+    subtotal,
+    tax: 0,
+    total: Number(base.total ?? subtotal),
+    createdAt: base.created_at,
+    updatedAt: base.updated_at,
+  };
+}
+
+async function recalculateInvoiceTotal(client: Queryable, tenantId: string, invoiceId: string) {
+  await client.query(
+    `UPDATE invoices
+     SET total = COALESCE((
+       SELECT SUM(qty * unit_price)
+       FROM invoice_lines
+       WHERE invoice_id = $1 AND tenant_id = $2
+     ), 0),
+         updated_at = NOW()
+     WHERE id = $1 AND tenant_id = $2`,
+    [invoiceId, tenantId],
+  );
+}
+
+async function resolveInvoiceLine(client: Queryable, tenantId: string, invoiceId: string, lineRef: InvoiceLineRef) {
+  if (lineRef.lineId) {
+    const lineRes = await client.query<{ id: string }>(
+      `SELECT id
+       FROM invoice_lines
+       WHERE id = $1 AND invoice_id = $2 AND tenant_id = $3`,
+      [lineRef.lineId, invoiceId, tenantId],
+    );
+    if (lineRes.rowCount === 1) {
+      return lineRes.rows[0];
+    }
+    throw new Error('Sales order line not found');
+  }
+
+  if (lineRef.sizeId) {
+    const lineRes = await client.query<{ id: string }>(
+      `SELECT id
+       FROM invoice_lines
+       WHERE invoice_id = $1 AND tenant_id = $2 AND size_id = $3`,
+      [invoiceId, tenantId, lineRef.sizeId],
+    );
+    if (lineRes.rowCount === 1) {
+      return lineRes.rows[0];
+    }
+    throw new Error('Sales order line not found');
+  }
+
+  const skuCode = String(lineRef.skuCode || '').trim().toUpperCase();
+  const sizeLabel = String(lineRef.sizeLabel || '').trim().toUpperCase();
+  const lineRes = await client.query<{ id: string }>(
+    `SELECT il.id
+     FROM invoice_lines il
+     JOIN sku_sizes sz ON sz.id = il.size_id
+     JOIN skus s ON s.id = sz.sku_id
+     WHERE il.invoice_id = $1
+       AND il.tenant_id = $2
+       AND UPPER(s.sku_code) = $3
+       AND UPPER(sz.size_label) = $4`,
+    [invoiceId, tenantId, skuCode, sizeLabel],
+  );
+  if (lineRes.rowCount === 1) {
+    return lineRes.rows[0];
+  }
+  throw new Error('Sales order line not found');
+}
+
+async function applyInvoiceLineOps(client: Queryable, tenantId: string, invoiceId: string, lineOps: InvoiceLineOp[]) {
+  for (const lineOp of lineOps) {
+    if (lineOp.op === 'add') {
+      const values = lineOp.values!;
+      await client.query(
+        `INSERT INTO invoice_lines (tenant_id, invoice_id, size_id, qty, unit_price)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [tenantId, invoiceId, values.sizeId, values.qty, values.unitPrice],
+      );
+      continue;
+    }
+
+    const resolvedLine = await resolveInvoiceLine(client, tenantId, invoiceId, lineOp.lineRef!);
+    if (lineOp.op === 'replace') {
+      const values = lineOp.values!;
+      await client.query(
+        `UPDATE invoice_lines
+         SET size_id = $1, qty = $2, unit_price = $3
+         WHERE id = $4 AND tenant_id = $5`,
+        [values.sizeId, values.qty, values.unitPrice, resolvedLine.id, tenantId],
+      );
+      continue;
+    }
+    if (lineOp.op === 'change_qty') {
+      await client.query(
+        `UPDATE invoice_lines
+         SET qty = $1
+         WHERE id = $2 AND tenant_id = $3`,
+        [lineOp.qty, resolvedLine.id, tenantId],
+      );
+      continue;
+    }
+    if (lineOp.op === 'change_price') {
+      await client.query(
+        `UPDATE invoice_lines
+         SET unit_price = $1
+         WHERE id = $2 AND tenant_id = $3`,
+        [lineOp.unitPrice, resolvedLine.id, tenantId],
+      );
+      continue;
+    }
+    if (lineOp.op === 'remove') {
+      await client.query(
+        `DELETE FROM invoice_lines
+         WHERE id = $1 AND tenant_id = $2`,
+        [resolvedLine.id, tenantId],
+      );
+    }
+  }
 }
 
 export async function listInvoices(req: Request, res: Response) {
@@ -87,64 +362,11 @@ export async function listInvoices(req: Request, res: Response) {
 }
 
 export async function getInvoice(req: Request, res: Response) {
-  const invoiceRes = await pool.query(
-    `SELECT
-       i.id,
-       i.customer_id,
-       c.name AS customer_name,
-       i.status,
-       i.total,
-       i.created_at,
-       i.updated_at
-     FROM invoices i
-     JOIN customers c ON c.id = i.customer_id
-     WHERE i.id = $1 AND i.tenant_id = $2`,
-    [req.params.id, req.user!.tenantId],
-  );
-  if (invoiceRes.rowCount === 0) {
+  const invoice = await getInvoiceById(pool, req.user!.tenantId, req.params.id);
+  if (!invoice) {
     return res.status(404).json({ message: 'Invoice not found' });
   }
-
-  const linesRes = await pool.query(
-    `SELECT
-       il.id,
-       il.size_id,
-       il.qty,
-       il.unit_price,
-       s.sku_code,
-       sz.size_label
-     FROM invoice_lines il
-     JOIN sku_sizes sz ON sz.id = il.size_id
-     JOIN skus s ON s.id = sz.sku_id
-     WHERE il.invoice_id = $1 AND il.tenant_id = $2
-     ORDER BY il.id`,
-    [req.params.id, req.user!.tenantId],
-  );
-
-  const lines = linesRes.rows.map((line) => ({
-    id: line.id,
-    skuId: line.size_id,
-    sku: `${line.sku_code}-${line.size_label}`,
-    qty: Number(line.qty ?? 0),
-    unitPrice: Number(line.unit_price ?? 0),
-  }));
-
-  const base = invoiceRes.rows[0];
-  const subtotal = lines.reduce((sum, line) => sum + line.qty * line.unitPrice, 0);
-  return res.json({
-    id: base.id,
-    number: `SO-${String(base.id).slice(0, 8).toUpperCase()}`,
-    customerId: base.customer_id,
-    customerName: base.customer_name,
-    status: base.status,
-    currency: 'USD',
-    lines,
-    subtotal,
-    tax: 0,
-    total: Number(base.total ?? subtotal),
-    createdAt: base.created_at,
-    updatedAt: base.updated_at,
-  });
+  return res.json(invoice);
 }
 
 export async function createInvoice(req: Request, res: Response) {
@@ -176,7 +398,7 @@ export async function dispatchInvoice(req: Request, res: Response) {
 
 export async function cancelInvoice(req: Request, res: Response) {
   try {
-    const result = await executeCancelInvoice(req.user!.id, req.user!.tenantId, req.params.id);
+    const result = await executeCancelInvoice(req.user!.id, req.user!.tenantId, req.params.id, req.body);
     res.json(result);
   } catch (err: any) {
     res.status(400).json({ message: err.message ?? 'Failed' });
@@ -195,18 +417,20 @@ export async function executeCreateInvoice(actorId: string, tenantId: string, pa
     const invRes = await client.query(
       `INSERT INTO invoices (tenant_id, customer_id, status, total, created_by)
        VALUES ($1,$2,'draft',$3,$4) RETURNING id`,
-      [tenantId, body.customerId, total, actorId]
+      [tenantId, body.customerId, total, actorId],
     );
     const id = invRes.rows[0].id;
     for (const line of body.lines) {
       await client.query(
         `INSERT INTO invoice_lines (tenant_id, invoice_id, size_id, qty, unit_price)
          VALUES ($1,$2,$3,$4,$5)`,
-        [tenantId, id, line.sizeId, line.qty, line.unitPrice]
+        [tenantId, id, line.sizeId, line.qty, line.unitPrice],
       );
     }
     await client.query('COMMIT');
-    return { id };
+    const created = await getInvoiceById(client, tenantId, id);
+    if (!created) throw new Error('Failed to load created invoice');
+    return created;
   } catch (err) {
     await client.query('ROLLBACK');
     throw err;
@@ -216,16 +440,29 @@ export async function executeCreateInvoice(actorId: string, tenantId: string, pa
 }
 
 export async function executeUpdateInvoice(actorId: string, tenantId: string, invoiceId: string, payload: any) {
-  const parsed = invoiceSchema.partial().safeParse(payload);
+  const parsed = invoiceUpdateSchema.safeParse(payload);
   if (!parsed.success) throw new Error('Invalid payload');
   const body = parsed.data;
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
+    const headerPatch = {
+      ...(body.headerPatch ?? {}),
+      ...(hasOwn(body, 'customerId') ? { customerId: body.customerId } : {}),
+    };
+    const setClauses: string[] = ['updated_at = NOW()'];
+    const values: string[] = [];
+    if (hasOwn(headerPatch, 'customerId') && headerPatch.customerId) {
+      values.push(headerPatch.customerId);
+      setClauses.push(`customer_id = $${values.length}`);
+    }
+    values.push(invoiceId, tenantId);
     const invRes = await client.query(
-      `UPDATE invoices SET customer_id = COALESCE($1, customer_id), updated_at = NOW()
-       WHERE id = $2 AND tenant_id = $3 AND status = 'draft' RETURNING id`,
-      [body.customerId ?? null, invoiceId, tenantId]
+      `UPDATE invoices
+       SET ${setClauses.join(', ')}
+       WHERE id = $${values.length - 1} AND tenant_id = $${values.length} AND status = 'draft'
+       RETURNING id`,
+      values,
     );
     if (invRes.rowCount === 0) throw new Error('Invoice not found or not editable');
     if (body.lines) {
@@ -238,8 +475,16 @@ export async function executeUpdateInvoice(actorId: string, tenantId: string, in
         );
       }
     }
+    if (body.lineOps) {
+      await applyInvoiceLineOps(client, tenantId, invoiceId, body.lineOps);
+    }
+    if (body.lines || body.lineOps) {
+      await recalculateInvoiceTotal(client, tenantId, invoiceId);
+    }
     await client.query('COMMIT');
-    return { id: invoiceId };
+    const updated = await getInvoiceById(client, tenantId, invoiceId);
+    if (!updated) throw new Error('Failed to load updated invoice');
+    return updated;
   } catch (err) {
     await client.query('ROLLBACK');
     throw err;
@@ -279,11 +524,18 @@ export async function executeDispatchInvoice(actorId: string, tenantId: string, 
       await client.query(
         `UPDATE stock_balances SET on_hand = on_hand - $1, updated_at = NOW()
          WHERE tenant_id = $2 AND size_id = $3 AND location_id = $4`,
-        [line.qty, tenantId, line.size_id, body.locationId]
+        [line.qty, tenantId, line.size_id, body.locationId],
       );
     }
 
-    await client.query(`UPDATE invoices SET status = 'sent', updated_at = NOW() WHERE id = $1 AND tenant_id = $2`, [invoiceId, tenantId]);
+    await client.query(
+      `UPDATE invoices
+       SET status = 'sent',
+           dispatched_location_id = $3,
+           updated_at = NOW()
+       WHERE id = $1 AND tenant_id = $2`,
+      [invoiceId, tenantId, body.locationId],
+    );
     await client.query('COMMIT');
     return { id: invoiceId, status: 'sent' };
   } catch (err) {
@@ -294,10 +546,66 @@ export async function executeDispatchInvoice(actorId: string, tenantId: string, 
   }
 }
 
-export async function executeCancelInvoice(actorId: string, tenantId: string, invoiceId: string) {
-  await pool.query(
-    `UPDATE invoices SET status = 'cancelled', updated_at = NOW() WHERE id = $1 AND tenant_id = $2`,
-    [invoiceId, tenantId]
-  );
-  return { id: invoiceId, status: 'cancelled' };
+export async function executeCancelInvoice(actorId: string, tenantId: string, invoiceId: string, payload: any) {
+  const parsed = confirmSchema.safeParse(payload);
+  if (!parsed.success) throw new Error('Confirmation required');
+
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    const invRes = await client.query(
+      `SELECT status, dispatched_location_id
+       FROM invoices
+       WHERE id = $1
+         AND tenant_id = $2
+         AND status NOT IN ('cancelled', 'closed')
+       FOR UPDATE`,
+      [invoiceId, tenantId],
+    );
+    if (invRes.rowCount === 0) {
+      throw new Error('Invoice not found or already cancelled/closed');
+    }
+
+    const { status, dispatched_location_id: dispatchedLocationId } = invRes.rows[0];
+
+    if (status === 'sent') {
+      if (!dispatchedLocationId) {
+        throw new Error('Invoice is missing dispatched location');
+      }
+
+      const linesRes = await client.query(
+        `SELECT size_id, qty
+         FROM invoice_lines
+         WHERE invoice_id = $1 AND tenant_id = $2`,
+        [invoiceId, tenantId],
+      );
+
+      for (const line of linesRes.rows) {
+        await client.query(
+          `INSERT INTO stock_balances (tenant_id, size_id, location_id, on_hand, reserved)
+           VALUES ($1, $2, $3, $4, 0)
+           ON CONFLICT (tenant_id, size_id, location_id)
+           DO UPDATE SET on_hand = stock_balances.on_hand + EXCLUDED.on_hand, updated_at = NOW()`,
+          [tenantId, line.size_id, dispatchedLocationId, line.qty],
+        );
+      }
+    }
+
+    await client.query(
+      `UPDATE invoices
+       SET status = 'cancelled',
+           updated_at = NOW()
+       WHERE id = $1 AND tenant_id = $2`,
+      [invoiceId, tenantId],
+    );
+
+    await client.query('COMMIT');
+    return { id: invoiceId, status: 'cancelled' };
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
 }

--- a/backend/src/scripts/seed.ts
+++ b/backend/src/scripts/seed.ts
@@ -17,6 +17,7 @@ const ALL_PERMISSIONS = [
   'master.write',
   'purchasing.read',
   'purchasing.write',
+  'sales.read',
   'sales.write',
   'audit.read',
   'chat.use',
@@ -116,7 +117,7 @@ const ROLE_SEEDS: RoleSeed[] = [
   },
   {
     name: 'sales_manager',
-    permissions: ['sales.write', 'inventory.read', 'products.read', 'master.read', 'audit.read', 'chat.use'],
+    permissions: ['sales.read', 'sales.write', 'inventory.read', 'products.read', 'master.read', 'audit.read', 'chat.use'],
   },
   {
     name: 'catalog_manager',

--- a/conversational-engine/src/conversational_engine/agents/entity_resolver.py
+++ b/conversational-engine/src/conversational_engine/agents/entity_resolver.py
@@ -7,6 +7,10 @@ from conversational_engine.clients.backend import BackendClient
 from conversational_engine.contracts.auth import AuthContext
 
 
+# NOTE: There are currently two EntityResolver implementations:
+# - this agent-facing resolver for the legacy orchestrator path
+# - tools/catalog/resolvers.py for the runtime semantic tool path
+# Keep their behavior aligned until they are merged into one implementation.
 class EntityResolver:
     def __init__(self, backend: BackendClient) -> None:
         self._backend = backend

--- a/conversational-engine/src/conversational_engine/agents/executor.py
+++ b/conversational-engine/src/conversational_engine/agents/executor.py
@@ -1,11 +1,29 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-import json
+import re
 from typing import Any
 
 from conversational_engine.providers.router import ProviderRouter, ProviderTrace
 from conversational_engine.providers.runtime import ProviderMessage
+from conversational_engine.utils.json_parsing import parse_json_object, strip_markdown_fences
+
+# Keys that are part of the executor response envelope, not tool arguments.
+_SCHEMA_KEYS = frozenset({
+    'action',
+    'assistantMessage',
+    'toolName',
+    'toolArguments',
+    'toolArgumentsJson',
+    'requiredInputs',
+    'tool',
+    'tool_name',
+    'arguments',
+    'parameters',
+})
+
+# Matches dotted tool names like "master.create_supplier" or "products.create_product".
+_DOTTED_TOOL_NAME_RE = re.compile(r'^[a-z_]+\.[a-z_]+$')
 
 EXECUTOR_SCHEMA = {
     'type': 'object',
@@ -36,6 +54,7 @@ class ExecutorAgent:
         plan: dict[str, Any],
         tools: list[dict[str, Any]],
         history: list[dict[str, Any]],
+        expected_tool_name: str | None = None,
         trace_callback: Callable[[str, ProviderTrace], None] | None = None,
     ) -> dict[str, Any]:
         response = await self._router.complete_json(
@@ -66,18 +85,33 @@ class ExecutorAgent:
             trace_callback=trace_callback,
         )
         parsed = response.parsed or {}
-        parsed = _normalize_executor_payload(parsed)
+        parsed = _normalize_executor_payload(parsed, expected_tool_name=expected_tool_name)
         return parsed
 
 
-def _normalize_executor_payload(parsed: dict[str, Any]) -> dict[str, Any]:
+def _normalize_executor_payload(
+    parsed: dict[str, Any],
+    *,
+    expected_tool_name: str | None = None,
+) -> dict[str, Any]:
     normalized = dict(parsed)
 
+    # Recovery 1: toolName from aliased keys 'tool' or 'tool_name'.
     if not normalized.get('toolName'):
         fallback_tool_name = normalized.get('tool') or normalized.get('tool_name')
         if isinstance(fallback_tool_name, str) and fallback_tool_name.strip():
             normalized['toolName'] = fallback_tool_name
 
+    # Recovery 2: toolName from 'name' when it looks like a dotted tool path
+    # e.g. {'name': 'master.create_supplier', 'toolArguments': {...}}.
+    name_promoted = False
+    if not normalized.get('toolName'):
+        name_val = normalized.get('name')
+        if isinstance(name_val, str) and _DOTTED_TOOL_NAME_RE.match(name_val.strip()):
+            normalized['toolName'] = name_val.strip()
+            name_promoted = True
+
+    # Resolve toolArguments via existing logic.
     parsed_tool_arguments = _parse_tool_arguments(normalized.get('toolArguments'))
     if parsed_tool_arguments is None:
         raw_arguments = (
@@ -86,7 +120,26 @@ def _normalize_executor_payload(parsed: dict[str, Any]) -> dict[str, Any]:
             else normalized.get('arguments') or normalized.get('parameters')
         )
         parsed_tool_arguments = _parse_tool_arguments(raw_arguments)
+
+    # Recovery 3: when toolArguments is still None, collect any top-level keys
+    # that are not part of the executor response envelope.  This handles the
+    # case where the LLM puts tool arguments directly on the root object, e.g.:
+    #   {'name': 'saitees', 'styleCode': 'sai-0204', ..., 'toolArguments': None}
+    if parsed_tool_arguments is None:
+        excluded = set(_SCHEMA_KEYS)
+        if name_promoted:
+            # 'name' was promoted to toolName — don't also include it as an argument.
+            excluded.add('name')
+        top_level = {k: v for k, v in normalized.items() if k not in excluded}
+        if top_level:
+            parsed_tool_arguments = top_level
+
     normalized['toolArguments'] = parsed_tool_arguments
+
+    # Recovery 4: last-resort toolName from the caller-supplied expected intent,
+    # used when the LLM omits toolName entirely but the planner already resolved it.
+    if not normalized.get('toolName') and expected_tool_name:
+        normalized['toolName'] = expected_tool_name
 
     normalized.pop('toolArgumentsJson', None)
     return normalized
@@ -98,12 +151,12 @@ def _parse_tool_arguments(raw_arguments: Any) -> dict[str, Any] | None:
     if isinstance(raw_arguments, dict):
         return raw_arguments
     if isinstance(raw_arguments, str):
-        stripped = raw_arguments.strip()
+        stripped = strip_markdown_fences(raw_arguments)
         if not stripped:
             return None
         try:
-            decoded = json.loads(stripped)
-        except json.JSONDecodeError:
+            decoded = parse_json_object(stripped, source='Executor')
+        except RuntimeError:
             decoded = _extract_json_object(stripped)
         if not isinstance(decoded, dict):
             raise RuntimeError('Executor returned a non-object tool argument payload')
@@ -112,6 +165,8 @@ def _parse_tool_arguments(raw_arguments: Any) -> dict[str, Any] | None:
 
 
 def _extract_json_object(raw_arguments: str) -> dict[str, Any] | None:
+    import json
+
     decoder = json.JSONDecoder()
     for start in (index for index, char in enumerate(raw_arguments) if char == '{'):
         try:

--- a/conversational-engine/src/conversational_engine/agents/inventory.py
+++ b/conversational-engine/src/conversational_engine/agents/inventory.py
@@ -239,6 +239,10 @@ class InventoryAgent(Agent):
                     rows=rows[:25],
                 ),
             ]
+            if len(rows) > 25:
+                blocks.append(
+                    TextBlock(content='Showing the first 25 stock rows. Refine the search to narrow the result.')
+                )
             return AgentTurnResult(next_action='return_read_result', memory_updates=memory_updates, blocks=blocks)
 
         missing_fields = self._missing_fields(intent, merged)

--- a/conversational-engine/src/conversational_engine/agents/narrator.py
+++ b/conversational-engine/src/conversational_engine/agents/narrator.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-import json
 from typing import Any
 
 from conversational_engine.providers.router import ProviderRouter, ProviderTrace
 from conversational_engine.providers.runtime import ProviderMessage
+from conversational_engine.utils.json_parsing import parse_json_object
 
 NARRATOR_SCHEMA = {
     'type': 'object',
@@ -134,25 +134,33 @@ class NarratorAgent:
         if not cleaned:
             return ''
         try:
-            payload = json.loads(cleaned)
-        except json.JSONDecodeError:
+            payload = parse_json_object(cleaned, source='Narrator')
+        except RuntimeError:
             return cleaned
-        if isinstance(payload, dict):
-            message = payload.get('message')
-            if isinstance(message, str):
-                return message.strip()
+        message = payload.get('message')
+        if isinstance(message, str):
+            return message.strip()
         return cleaned
 
     @staticmethod
     def _looks_like_internal_instruction(message: str, directive: str) -> bool:
         normalized_message = ' '.join(message.split()).strip().lower()
-        normalized_directive = ' '.join(directive.split()).strip().lower()
         if not normalized_message:
             return True
-        if normalized_message == normalized_directive:
-            return True
+        normalized_directive = ' '.join(directive.split()).strip().lower()
+        # Reject messages that are literally meta-instructions leaked from the prompt.
+        # NOTE: Do NOT reject messages that happen to match the directive — a clarification
+        # question directive IS the message we want to send to the user.
         if normalized_message.startswith('reply naturally to the user'):
             return True
+        if normalized_message.startswith('reply to the user in'):
+            return True
         if normalized_message.startswith('directive for what to communicate'):
+            return True
+        if normalized_message.startswith('write a natural'):
+            return True
+        if normalized_message.startswith('communicate that'):
+            return True
+        if normalized_message == normalized_directive and normalized_message.startswith('reply to the user'):
             return True
         return False

--- a/conversational-engine/src/conversational_engine/agents/parsing.py
+++ b/conversational-engine/src/conversational_engine/agents/parsing.py
@@ -25,14 +25,14 @@ def parse_uuid(text: str) -> str | None:
 
 def parse_money(text: str) -> int | None:
     patterns = [
-        r'(?:\$|cost|unit cost|base price|price|prce)\s*(?:is|of|=)?\s*(\d+)',
-        r'\b(\d+)\s*(?:gbp|usd|eur|pounds?|dollars?)\b',
-        r'@\s*(\d+)',
+        r'(?:\$|cost|unit cost|base price|price|prce)\s*(?:is|of|=)?\s*(\d+(?:\.\d{1,2})?)',
+        r'\b(\d+(?:\.\d{1,2})?)\s*(?:gbp|usd|eur|pounds?|dollars?)\b',
+        r'@\s*(\d+(?:\.\d{1,2})?)',
     ]
     for pattern in patterns:
         match = re.search(pattern, text, re.IGNORECASE)
         if match:
-            return int(match.group(1))
+            return int(round(float(match.group(1)) * 100))
     return None
 
 
@@ -85,4 +85,3 @@ def json_safe_row(row: dict[str, Any]) -> dict[str, object]:
         else:
             safe[key] = value
     return safe
-

--- a/conversational-engine/src/conversational_engine/agents/planner.py
+++ b/conversational-engine/src/conversational_engine/agents/planner.py
@@ -44,7 +44,14 @@ class PlannerAgent:
                     content=(
                         'You are the planning agent for an internal inventory AI runtime. '
                         'Own semantic routing, clarification, and tool strategy. '
-                        'Never invent tool names outside the provided catalog.'
+                        'Never invent tool names outside the provided catalog.\n\n'
+                        'When action is "clarify", set clarificationQuestion to a concise, '
+                        'domain-specific question that names exactly what field(s) are missing. '
+                        'For example: '
+                        '"What is the supplier name? You can also provide email, phone, and address." '
+                        'or "What is the customer name?" or "What is the product name, style code, and base price?". '
+                        'Never use generic phrases like "How can I help?" or "Please clarify your request." — '
+                        'always reference the specific tool or entity being created or updated.'
                     ),
                 ),
                 ProviderMessage(

--- a/conversational-engine/src/conversational_engine/agents/reviewer.py
+++ b/conversational-engine/src/conversational_engine/agents/reviewer.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-import json
 from typing import Any
 
 from conversational_engine.providers.router import ProviderRouter, ProviderTrace
 from conversational_engine.providers.runtime import ProviderMessage
+from conversational_engine.utils.json_parsing import parse_json_object
 
 REVIEWER_SCHEMA = {
     'type': 'object',
@@ -14,7 +14,7 @@ REVIEWER_SCHEMA = {
         'action': {'type': 'string', 'enum': ['complete', 'continue', 'clarify']},
         'assistantMessage': {'type': 'string'},
         'feedback': {'type': ['string', 'null']},
-        'requiredInputs': {'type': 'array', 'items': {'type': 'string'}},
+        'requiredInputs': {'type': 'array', 'items': {'type': 'string'}, 'minItems': 0},
         'includeTable': {'type': 'boolean'},
         'resolvedEntitiesJson': {'type': 'string'},
     },
@@ -78,13 +78,7 @@ def _normalize_reviewer_payload(parsed: dict[str, Any]) -> dict[str, Any]:
     normalized = dict(parsed)
     raw_entities = normalized.get('resolvedEntitiesJson')
     if isinstance(raw_entities, str):
-        try:
-            decoded = json.loads(raw_entities)
-        except json.JSONDecodeError as exc:
-            raise RuntimeError('Reviewer returned invalid resolvedEntitiesJson') from exc
-        if not isinstance(decoded, dict):
-            raise RuntimeError('Reviewer returned non-object resolvedEntitiesJson')
-        normalized['resolvedEntities'] = decoded
+        normalized['resolvedEntities'] = parse_json_object(raw_entities, source='Reviewer')
     elif isinstance(raw_entities, dict):
         normalized['resolvedEntities'] = raw_entities
     else:

--- a/conversational-engine/src/conversational_engine/agents/state_updater.py
+++ b/conversational-engine/src/conversational_engine/agents/state_updater.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-import json
 from typing import Any
 
 from conversational_engine.providers.router import ProviderRouter, ProviderTrace
 from conversational_engine.providers.runtime import ProviderMessage
+from conversational_engine.utils.json_parsing import parse_json_object
 
 STATE_UPDATER_SCHEMA = {
     'type': 'object',
@@ -132,13 +132,7 @@ def _normalize_state_update_payload(parsed: dict[str, Any]) -> dict[str, Any]:
 
     raw_patches = normalized.get('entityPatchesJson')
     if isinstance(raw_patches, str):
-        try:
-            decoded = json.loads(raw_patches)
-        except json.JSONDecodeError as exc:
-            raise RuntimeError('State updater returned invalid entityPatchesJson') from exc
-        if not isinstance(decoded, dict):
-            raise RuntimeError('State updater returned non-object entityPatchesJson')
-        normalized['entityPatches'] = decoded
+        normalized['entityPatches'] = parse_json_object(raw_patches, source='State updater')
     elif isinstance(raw_patches, dict):
         normalized['entityPatches'] = raw_patches
     else:

--- a/conversational-engine/src/conversational_engine/ai/mongo_repository.py
+++ b/conversational-engine/src/conversational_engine/ai/mongo_repository.py
@@ -93,6 +93,7 @@ def _conversation_from_doc(doc: dict[str, Any]) -> ConversationDetail:
         {
             'id': doc['_id'],
             'title': doc['title'],
+            'createdBy': doc.get('createdBy'),
             'createdAt': doc['createdAt'],
             'updatedAt': doc['updatedAt'],
         }
@@ -181,6 +182,13 @@ class MongoAIRepository(AIRepository):
         await self._db.ai_traces.create_index([('tenantId', ASCENDING), ('agentRole', ASCENDING), ('createdAt', DESCENDING)])
         await self._db.ai_traces.create_index([('tenantId', ASCENDING), ('createdAt', DESCENDING)])
         await self._db.ai_traces.create_index('expiresAt', expireAfterSeconds=0)
+
+        await self._db.ai_audit_events.create_index([('tenantId', ASCENDING), ('createdAt', DESCENDING)])
+        await self._db.ai_audit_events.create_index([('tenantId', ASCENDING), ('conversationId', ASCENDING), ('createdAt', DESCENDING)])
+        await self._db.ai_audit_events.create_index([('tenantId', ASCENDING), ('workflowId', ASCENDING), ('createdAt', DESCENDING)])
+        await self._db.ai_audit_events.create_index([('tenantId', ASCENDING), ('approvalId', ASCENDING), ('createdAt', DESCENDING)])
+        await self._db.ai_audit_events.create_index([('tenantId', ASCENDING), ('eventType', ASCENDING), ('createdAt', DESCENDING)])
+        await self._db.ai_audit_events.create_index('expiresAt', expireAfterSeconds=0)
 
         await self._db.ai_entity_memory.create_index([('tenantId', ASCENDING), ('conversationId', ASCENDING), ('createdAt', DESCENDING)])
         await self._db.ai_entity_memory.create_index([('tenantId', ASCENDING), ('userId', ASCENDING), ('createdAt', DESCENDING)])
@@ -694,6 +702,52 @@ class MongoAIRepository(AIRepository):
             )
             for doc in docs
         ]
+
+    async def record_audit_event(
+        self,
+        *,
+        tenant_id: str,
+        user_id: str | None,
+        actor_email: str | None,
+        event_type: str,
+        conversation_id: str | None = None,
+        workflow_id: str | None = None,
+        approval_id: str | None = None,
+        tool_name: str | None = None,
+        payload: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        now = utc_now()
+        doc = {
+            '_id': str(uuid4()),
+            'tenantId': tenant_id,
+            'userId': user_id,
+            'actorEmail': actor_email,
+            'eventType': event_type,
+            'conversationId': conversation_id,
+            'workflowId': workflow_id,
+            'approvalId': approval_id,
+            'toolName': tool_name,
+            'payload': payload or {},
+            'createdAt': now,
+            'expiresAt': await self._get_retention_expiry(tenant_id, 'raw_messages', now=now),
+        }
+        await self._db.ai_audit_events.insert_one(doc)
+        return doc
+
+    async def list_audit_events(
+        self,
+        *,
+        tenant_id: str,
+        limit: int,
+        conversation_id: str | None = None,
+        workflow_id: str | None = None,
+    ) -> list[dict[str, object]]:
+        filters: dict[str, Any] = {'tenantId': tenant_id}
+        if conversation_id:
+            filters['conversationId'] = conversation_id
+        if workflow_id:
+            filters['workflowId'] = workflow_id
+        return await self._db.ai_audit_events.find(filters).sort('createdAt', DESCENDING).limit(limit).to_list(length=limit)
 
     async def record_trace(
         self,

--- a/conversational-engine/src/conversational_engine/ai/repository.py
+++ b/conversational-engine/src/conversational_engine/ai/repository.py
@@ -237,6 +237,29 @@ class AIRepository(Protocol):
 
     async def list_business_memory(self, tenant_id: str, *, limit: int) -> list[dict[str, object]]: ...
 
+    async def record_audit_event(
+        self,
+        *,
+        tenant_id: str,
+        user_id: str | None,
+        actor_email: str | None,
+        event_type: str,
+        conversation_id: str | None = None,
+        workflow_id: str | None = None,
+        approval_id: str | None = None,
+        tool_name: str | None = None,
+        payload: dict[str, object] | None = None,
+    ) -> dict[str, object]: ...
+
+    async def list_audit_events(
+        self,
+        *,
+        tenant_id: str,
+        limit: int,
+        conversation_id: str | None = None,
+        workflow_id: str | None = None,
+    ) -> list[dict[str, object]]: ...
+
     async def upsert_user_memory(
         self,
         *,

--- a/conversational-engine/src/conversational_engine/app/dependencies.py
+++ b/conversational-engine/src/conversational_engine/app/dependencies.py
@@ -17,6 +17,7 @@ from conversational_engine.agents.narrator import NarratorAgent
 from conversational_engine.agents.planner import PlannerAgent
 from conversational_engine.agents.reviewer import ReviewerAgent
 from conversational_engine.agents.state_updater import StateUpdateAgent
+from conversational_engine.audit.service import AuditService
 from conversational_engine.clients.backend import BackendClient
 from conversational_engine.config.settings import Settings, get_settings
 from conversational_engine.conversations.service import ConversationService
@@ -34,6 +35,7 @@ class AppServices:
     backend_client: BackendClient
     repository: MongoAIRepository
     redis_cache: RedisActiveStateCache
+    audit_service: AuditService
     attachment_service: S3AttachmentService
     semantic_memory_service: SemanticMemoryService
     tenant_settings_service: TenantAISettingsService
@@ -43,9 +45,15 @@ class AppServices:
 
 
 def build_app_services(*, settings: Settings, mongo_client, redis_client, s3_client) -> AppServices:
-    backend_client = BackendClient(settings.backend_base_url)
+    backend_client = BackendClient(
+        settings.backend_base_url,
+        max_connections=settings.backend_http_max_connections,
+        max_keepalive_connections=settings.backend_http_max_keepalive_connections,
+        retry_attempts=settings.backend_http_retry_attempts,
+    )
     repository = MongoAIRepository(mongo_client, settings)
     redis_cache = RedisActiveStateCache(redis_client)
+    audit_service = AuditService(repository)
     semantic_memory_service = SemanticMemoryService(repository, settings)
     attachment_service = S3AttachmentService(repository, settings, s3_client)
     retrieval_service = RetrievalService(repository)
@@ -60,6 +68,7 @@ def build_app_services(*, settings: Settings, mongo_client, redis_client, s3_cli
         reviewer=ReviewerAgent(router),
         state_updater=StateUpdateAgent(router),
         narrator=NarratorAgent(router),
+        audit_service=audit_service,
         memory_service=LayeredMemoryService(
             repository=repository,
             settings=settings,
@@ -73,6 +82,7 @@ def build_app_services(*, settings: Settings, mongo_client, redis_client, s3_cli
         backend_client=backend_client,
         repository=repository,
         redis_cache=redis_cache,
+        audit_service=audit_service,
         attachment_service=attachment_service,
         semantic_memory_service=semantic_memory_service,
         tenant_settings_service=TenantAISettingsService(repository),
@@ -82,6 +92,7 @@ def build_app_services(*, settings: Settings, mongo_client, redis_client, s3_cli
             repository=repository,
             backend_client=backend_client,
             runtime_service=runtime_service,
+            audit_service=audit_service,
             attachment_service=attachment_service,
             redis_cache=redis_cache,
             settings=settings,
@@ -105,7 +116,12 @@ async def get_conversation_service(request: Request) -> ConversationService:
 @lru_cache(maxsize=1)
 def get_backend_client() -> BackendClient:
     settings = get_settings()
-    return BackendClient(settings.backend_base_url)
+    return BackendClient(
+        settings.backend_base_url,
+        max_connections=settings.backend_http_max_connections,
+        max_keepalive_connections=settings.backend_http_max_keepalive_connections,
+        retry_attempts=settings.backend_http_retry_attempts,
+    )
 
 
 async def get_retrieval_service(request: Request) -> RetrievalService:

--- a/conversational-engine/src/conversational_engine/app/main.py
+++ b/conversational-engine/src/conversational_engine/app/main.py
@@ -43,6 +43,7 @@ async def lifespan(app: FastAPI):
     try:
         yield
     finally:
+        await app.state.services.backend_client.aclose()
         mongo_client.close()
         if redis_client is not None:
             await redis_client.close()

--- a/conversational-engine/src/conversational_engine/audit/service.py
+++ b/conversational-engine/src/conversational_engine/audit/service.py
@@ -1,12 +1,48 @@
 from __future__ import annotations
 
+from conversational_engine.ai.repository import AIRepository
+
 
 class AuditService:
-    """Placeholder audit sink until backend audit integration lands."""
+    def __init__(self, repository: AIRepository) -> None:
+        self._repository = repository
 
-    async def record(self, event_type: str, payload: dict[str, object]) -> dict[str, object]:
-        return {
-            'eventType': event_type,
-            'recorded': False,
-            'payload': payload,
-        }
+    async def record(
+        self,
+        *,
+        tenant_id: str,
+        user_id: str | None,
+        actor_email: str | None,
+        event_type: str,
+        conversation_id: str | None = None,
+        workflow_id: str | None = None,
+        approval_id: str | None = None,
+        tool_name: str | None = None,
+        payload: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        return await self._repository.record_audit_event(
+            tenant_id=tenant_id,
+            user_id=user_id,
+            actor_email=actor_email,
+            event_type=event_type,
+            conversation_id=conversation_id,
+            workflow_id=workflow_id,
+            approval_id=approval_id,
+            tool_name=tool_name,
+            payload=payload or {},
+        )
+
+    async def list_recent_events(
+        self,
+        *,
+        tenant_id: str,
+        limit: int = 50,
+        conversation_id: str | None = None,
+        workflow_id: str | None = None,
+    ) -> list[dict[str, object]]:
+        return await self._repository.list_audit_events(
+            tenant_id=tenant_id,
+            limit=limit,
+            conversation_id=conversation_id,
+            workflow_id=workflow_id,
+        )

--- a/conversational-engine/src/conversational_engine/clients/backend.py
+++ b/conversational-engine/src/conversational_engine/clients/backend.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from uuid import uuid4
+import asyncio
+from contextlib import contextmanager
+from contextvars import ContextVar
+from hashlib import sha256
+import json
+import random
 
 import httpx
 
@@ -13,10 +18,62 @@ from conversational_engine.contracts.api import (
 )
 from conversational_engine.contracts.auth import AuthContext
 
+_IDEMPOTENCY_KEY: ContextVar[str | None] = ContextVar('backend_idempotency_key', default=None)
+
+
+class BackendRequestError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        message: str,
+        details: list[str] | None = None,
+        body: object | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+        self.details = details or []
+        self.body = body
+
+    @property
+    def user_message(self) -> str:
+        if self.details:
+            return '; '.join(self.details)
+        return self.message
+
+
+class BackendValidationError(BackendRequestError):
+    pass
+
+
+@contextmanager
+def idempotency_scope(key: str):
+    token = _IDEMPOTENCY_KEY.set(key)
+    try:
+        yield
+    finally:
+        _IDEMPOTENCY_KEY.reset(token)
+
 
 class BackendClient:
-    def __init__(self, base_url: str) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        max_connections: int = 20,
+        max_keepalive_connections: int = 10,
+        retry_attempts: int = 3,
+    ) -> None:
         self._base_url = base_url.rstrip('/')
+        self._retry_attempts = max(1, retry_attempts)
+        self._client = httpx.AsyncClient(
+            timeout=20.0,
+            limits=httpx.Limits(
+                max_connections=max_connections,
+                max_keepalive_connections=max_keepalive_connections,
+            ),
+        )
 
     def _headers(self, access_token: str, tenant_id: str | None) -> dict[str, str]:
         headers = {
@@ -37,19 +94,162 @@ class BackendClient:
         json: dict[str, object] | None = None,
         params: dict[str, object] | None = None,
     ) -> object:
-        async with httpx.AsyncClient(timeout=20.0) as client:
-            headers = self._headers(access_token, tenant_id)
-            if method.upper() in {'POST', 'PATCH', 'PUT', 'DELETE'}:
-                headers['Idempotency-Key'] = str(uuid4())
-            response = await client.request(
-                method,
-                f'{self._base_url}{path}',
-                headers=headers,
-                json=json,
+        normalized_method = method.upper()
+        headers = self._headers(access_token, tenant_id)
+        if normalized_method in {'POST', 'PATCH', 'PUT', 'DELETE'}:
+            headers['Idempotency-Key'] = self._idempotency_key(
+                method=normalized_method,
+                path=path,
+                tenant_id=tenant_id,
+                json_payload=json,
                 params=params,
             )
-            response.raise_for_status()
-        return response.json()
+        response = await self._request_with_retry(
+            normalized_method,
+            path,
+            headers=headers,
+            json=json,
+            params=params,
+        )
+        if response.is_success:
+            if not response.content:
+                return {}
+            return response.json()
+        raise self._error_from_response(response)
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    def _idempotency_key(
+        self,
+        *,
+        method: str,
+        path: str,
+        tenant_id: str | None,
+        json_payload: dict[str, object] | None,
+        params: dict[str, object] | None,
+    ) -> str:
+        scoped = _IDEMPOTENCY_KEY.get()
+        if scoped:
+            return scoped
+        fingerprint = json.dumps(
+            {
+                'method': method,
+                'path': path,
+                'tenantId': tenant_id,
+                'json': json_payload or {},
+                'params': params or {},
+            },
+            sort_keys=True,
+            separators=(',', ':'),
+        )
+        return f'auto:{sha256(fingerprint.encode("utf-8")).hexdigest()}'
+
+    def _error_from_response(self, response: httpx.Response) -> BackendRequestError:
+        body: object | None
+        try:
+            body = response.json()
+        except ValueError:
+            body = response.text.strip() or None
+
+        details = self._extract_error_details(body)
+        message = details[0] if details else f'Backend request failed with status {response.status_code}'
+        if response.status_code in {400, 409, 422}:
+            return BackendValidationError(
+                status_code=response.status_code,
+                message=message,
+                details=details,
+                body=body,
+            )
+        return BackendRequestError(
+            status_code=response.status_code,
+            message=message,
+            details=details,
+            body=body,
+        )
+
+    def _extract_error_details(self, body: object | None) -> list[str]:
+        if isinstance(body, dict):
+            message = body.get('message')
+            if isinstance(message, str) and message.strip():
+                details = [message.strip()]
+            else:
+                details = []
+
+            for key in ('errors', 'issues', 'details'):
+                raw = body.get(key)
+                if isinstance(raw, list):
+                    details.extend(self._flatten_error_items(raw))
+                elif isinstance(raw, dict):
+                    details.extend(self._flatten_error_items([raw]))
+
+            return list(dict.fromkeys(detail for detail in details if detail))
+
+        if isinstance(body, str) and body:
+            return [body]
+
+        return []
+
+    def _flatten_error_items(self, items: list[object]) -> list[str]:
+        flattened: list[str] = []
+        for item in items:
+            if isinstance(item, str) and item.strip():
+                flattened.append(item.strip())
+                continue
+            if not isinstance(item, dict):
+                continue
+            path = item.get('path')
+            message = item.get('message')
+            if isinstance(path, list):
+                rendered_path = '.'.join(str(part) for part in path if str(part))
+            elif isinstance(path, str):
+                rendered_path = path
+            else:
+                rendered_path = ''
+            if isinstance(message, str) and message.strip():
+                flattened.append(f'{rendered_path}: {message}'.strip(': '))
+        return flattened
+
+    async def _request_with_retry(
+        self,
+        method: str,
+        path: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, object] | None,
+        params: dict[str, object] | None,
+    ) -> httpx.Response:
+        can_retry = method in {'GET', 'HEAD'} or bool(headers.get('Idempotency-Key'))
+        last_exc: Exception | None = None
+
+        for attempt in range(1, self._retry_attempts + 1):
+            try:
+                response = await self._client.request(
+                    method,
+                    f'{self._base_url}{path}',
+                    headers=headers,
+                    json=json,
+                    params=params,
+                )
+            except httpx.TransportError as exc:
+                last_exc = exc
+                if not can_retry or attempt >= self._retry_attempts:
+                    raise RuntimeError(f'Backend transport failed: {exc}') from exc
+                await self._sleep_before_retry(attempt)
+                continue
+
+            if response.status_code < 500 or not can_retry or attempt >= self._retry_attempts:
+                return response
+
+            await self._sleep_before_retry(attempt)
+
+        if last_exc is not None:
+            raise RuntimeError(f'Backend transport failed: {last_exc}') from last_exc
+        raise RuntimeError('Backend request failed after retries.')
+
+    async def _sleep_before_retry(self, attempt: int) -> None:
+        base_delay = min(1.5, 0.15 * (2 ** (attempt - 1)))
+        await asyncio.sleep(base_delay + random.uniform(0.0, 0.1))
 
     async def resolve_auth_context(self, access_token: str, tenant_id: str | None) -> AuthContext:
         payload = await self._request('GET', '/auth/me', access_token, tenant_id)
@@ -113,7 +313,8 @@ class BackendClient:
         return await self._request('GET', '/master/categories', access_token, tenant_id)
 
     async def list_products(self, access_token: str, tenant_id: str) -> list[dict[str, object]]:
-        return await self._request('GET', '/products', access_token, tenant_id)
+        payload = await self._request('GET', '/products', access_token, tenant_id)
+        return self._product_items(payload)
 
     async def search_products(
         self,
@@ -125,11 +326,22 @@ class BackendClient:
         brand: str | None = None,
     ) -> list[dict[str, object]]:
         params = {k: v for k, v in {'q': q, 'color': color, 'category': category, 'brand': brand}.items() if v}
-        return await self._request('GET', '/products', access_token, tenant_id, params=params or None)
+        payload = await self._request('GET', '/products', access_token, tenant_id, params=params or None)
+        return self._product_items(payload)
 
     async def get_product(self, access_token: str, tenant_id: str, product_id: str) -> dict[str, object]:
         payload = await self._request('GET', f'/products/{product_id}', access_token, tenant_id)
         return payload
+
+    @staticmethod
+    def _product_items(payload: object) -> list[dict[str, object]]:
+        if isinstance(payload, list):
+            return [item for item in payload if isinstance(item, dict)]
+        if isinstance(payload, dict):
+            items = payload.get('items')
+            if isinstance(items, list):
+                return [item for item in items if isinstance(item, dict)]
+        return []
 
     async def create_product(self, access_token: str, tenant_id: str, payload: dict[str, object]) -> dict[str, object]:
         return await self._request('POST', '/products/compose', access_token, tenant_id, json=payload)
@@ -227,7 +439,22 @@ class BackendClient:
         return await self._request('POST', f'/purchasing/po/{po_id}/receive', access_token, tenant_id, json=payload)
 
     async def close_po(self, access_token: str, tenant_id: str, po_id: str) -> dict[str, object]:
-        return await self._request('POST', f'/purchasing/po/{po_id}/close', access_token, tenant_id, json={})
+        return await self._request(
+            'POST',
+            f'/purchasing/po/{po_id}/close',
+            access_token,
+            tenant_id,
+            json={'confirm': True},
+        )
+
+    async def cancel_po(self, access_token: str, tenant_id: str, po_id: str) -> dict[str, object]:
+        return await self._request(
+            'POST',
+            f'/purchasing/po/{po_id}/cancel',
+            access_token,
+            tenant_id,
+            json={'confirm': True},
+        )
 
     async def list_invoices(
         self,
@@ -262,7 +489,13 @@ class BackendClient:
         )
 
     async def cancel_invoice(self, access_token: str, tenant_id: str, invoice_id: str) -> dict[str, object]:
-        return await self._request('POST', f'/sales/invoice/{invoice_id}/cancel', access_token, tenant_id, json={})
+        return await self._request(
+            'POST',
+            f'/sales/invoice/{invoice_id}/cancel',
+            access_token,
+            tenant_id,
+            json={'confirm': True},
+        )
 
     async def reporting_stock_summary(
         self, access_token: str, tenant_id: str, params: dict[str, object]

--- a/conversational-engine/src/conversational_engine/config/settings.py
+++ b/conversational-engine/src/conversational_engine/config/settings.py
@@ -91,6 +91,9 @@ class Settings(BaseSettings):
         default='http://localhost:4000/api',
         validation_alias=AliasChoices('CONVERSATIONAL_ENGINE_BACKEND_BASE_URL', 'BACKEND_BASE_URL'),
     )
+    backend_http_max_connections: int = Field(default=20)
+    backend_http_max_keepalive_connections: int = Field(default=10)
+    backend_http_retry_attempts: int = Field(default=3)
 
     llm_base_url: str = Field(
         default='https://api.openai.com/v1',

--- a/conversational-engine/src/conversational_engine/contracts/common.py
+++ b/conversational-engine/src/conversational_engine/contracts/common.py
@@ -163,6 +163,7 @@ class ConversationSummary(ContractModel):
 class ConversationDetail(ContractModel):
     id: UUID
     title: str
+    created_by: str | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/conversational-engine/src/conversational_engine/contracts/runs.py
+++ b/conversational-engine/src/conversational_engine/contracts/runs.py
@@ -14,9 +14,9 @@ class ImageAttachment(ContractModel):
 
 
 class RunRequest(ContractModel):
-    content: str
+    content: str = Field(max_length=4000)
     conversation_id: UUID | None = None
-    title: str | None = None
+    title: str | None = Field(default=None, max_length=200)
     attachment_ids: list[str] = Field(default_factory=list)
     attachments: list[ImageAttachment] = Field(default_factory=list)
 

--- a/conversational-engine/src/conversational_engine/conversations/approval_executor.py
+++ b/conversational-engine/src/conversational_engine/conversations/approval_executor.py
@@ -1,19 +1,44 @@
 from __future__ import annotations
 
-from conversational_engine.clients.backend import BackendClient
+import logging
+
+from conversational_engine.audit.service import AuditService
+from conversational_engine.clients.backend import BackendClient, idempotency_scope
 from conversational_engine.contracts.auth import AuthContext
 from conversational_engine.contracts.common import ErrorBlock, WorkflowStatus
 from conversational_engine.orchestrator.service import OrchestratorOutcome
 from conversational_engine.runtime.renderer import render_navigation_blocks, render_tool_result
 from conversational_engine.runtime.state_update import build_post_action_blocks, mark_task_status
 from conversational_engine.tools.catalog import SemanticToolCatalog
+from conversational_engine.tools.catalog.utils import ToolPreparationError
+
+logger = logging.getLogger(__name__)
 
 
 class RuntimeApprovalExecutor:
-    def __init__(self, backend_client: BackendClient) -> None:
+    def __init__(self, backend_client: BackendClient, *, audit_service: AuditService | None = None) -> None:
         self._backend_client = backend_client
+        self._audit_service = audit_service
 
     async def execute(self, *, auth: AuthContext, approval) -> OrchestratorOutcome:
+        if approval.status not in {'approved', 'auto_approved', 'rejected'}:
+            return OrchestratorOutcome(
+                blocks=[
+                    ErrorBlock(
+                        title='Approval execution blocked',
+                        message='This approval request is not ready for execution.',
+                    )
+                ],
+                status=WorkflowStatus.FAILED,
+                current_task='approval_not_ready',
+                extracted_entities={
+                    'lastApprovalId': str(approval.id),
+                    'lastApprovalStatus': approval.status,
+                },
+                missing_fields=[],
+                active_approval_id=None,
+            )
+
         if approval.status == 'rejected':
             rejected_entities = mark_task_status(
                 {
@@ -57,11 +82,44 @@ class RuntimeApprovalExecutor:
                 active_approval_id=None,
             )
 
+        # NOTE: We intentionally skip catalog.validate() here.
+        # The execution_payload stored during confirmation is the *prepared* (normalised)
+        # output, whose shape may differ from the raw input_schema (e.g. products.create_product
+        # normalises to {product: {...}, variants: [...]} while the input_schema expects flat
+        # {styleCode, name, basePrice, variants}).  Calling catalog.invoke() already runs the
+        # preparer again (idempotent), so any structural issues will surface as ToolPreparationError.
         try:
-            result = await catalog.invoke(approval.tool_name, approval.execution_payload)
-        except Exception as exc:
+            with idempotency_scope(f'approval:{approval.id}'):
+                result = await catalog.invoke(approval.tool_name, approval.execution_payload)
+        except ToolPreparationError as exc:
+            logger.warning(
+                'Approval preparation error for approval %s: %s', approval.id, exc.prompt
+            )
             return OrchestratorOutcome(
-                blocks=[ErrorBlock(title='Approval execution failed', message=str(exc))],
+                blocks=[
+                    ErrorBlock(
+                        title='Approval execution failed',
+                        message=exc.prompt,
+                    )
+                ],
+                status=WorkflowStatus.FAILED,
+                current_task='approval_preparation_failed',
+                extracted_entities={
+                    'lastApprovalId': str(approval.id),
+                    'lastApprovalStatus': approval.status,
+                },
+                missing_fields=exc.missing_fields,
+                active_approval_id=None,
+            )
+        except Exception as exc:
+            logger.exception('Approval execution failed for approval %s', approval.id)
+            return OrchestratorOutcome(
+                blocks=[
+                    ErrorBlock(
+                        title='Approval execution failed',
+                        message='The approved action could not be completed.',
+                    )
+                ],
                 status=WorkflowStatus.FAILED,
                 current_task='approval_execution_failed',
                 extracted_entities={
@@ -73,27 +131,19 @@ class RuntimeApprovalExecutor:
             )
 
         task_context = approval.preview.get('taskContext') if isinstance(approval.preview, dict) else None
-        try:
-            await self._backend_client.record_audit_event(
-                access_token=auth.access_token or '',
-                tenant_id=auth.tenant_id,
-                payload={
-                    'conversationId': str(approval.conversation_id) if approval.conversation_id else None,
-                    'workflowId': str(approval.workflow_id) if approval.workflow_id else None,
-                    'approvalRequestId': str(approval.id),
-                    'eventType': 'execution_result',
-                    'payload': {
-                        'status': 'success',
-                        'toolName': approval.tool_name,
-                        'actionType': approval.action_type,
-                        'summary': approval.summary,
-                        'executionPayload': approval.execution_payload,
-                        'result': result,
-                    },
-                },
-            )
-        except Exception:
-            pass
+        await self._record_audit_event(
+            auth=auth,
+            approval=approval,
+            event_type='approval_executed',
+            payload={
+                'status': 'success',
+                'toolName': approval.tool_name,
+                'actionType': approval.action_type,
+                'summary': approval.summary,
+                'executionPayload': approval.execution_payload,
+                'result': result,
+            },
+        )
         next_entities = mark_task_status(
             {
                 'lastApprovalId': str(approval.id),
@@ -125,3 +175,28 @@ class RuntimeApprovalExecutor:
             missing_fields=[],
             active_approval_id=None,
         )
+
+    async def _record_audit_event(
+        self,
+        *,
+        auth: AuthContext,
+        approval,
+        event_type: str,
+        payload: dict[str, object],
+    ) -> None:
+        if self._audit_service is None:
+            return
+        try:
+            await self._audit_service.record(
+                tenant_id=auth.tenant_id,
+                user_id=auth.id,
+                actor_email=auth.email,
+                event_type=event_type,
+                conversation_id=str(approval.conversation_id) if approval.conversation_id else None,
+                workflow_id=str(approval.workflow_id) if approval.workflow_id else None,
+                approval_id=str(approval.id),
+                tool_name=approval.tool_name,
+                payload=payload,
+            )
+        except Exception:
+            logger.exception('Failed to persist approval audit event %s', event_type)

--- a/conversational-engine/src/conversational_engine/conversations/runtime_decisions.py
+++ b/conversational-engine/src/conversational_engine/conversations/runtime_decisions.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import logging
-from uuid import UUID
+from uuid import UUID, uuid4
 
-from conversational_engine.clients.backend import BackendClient
+from conversational_engine.audit.service import AuditService
+from conversational_engine.clients.backend import BackendClient, idempotency_scope
 from conversational_engine.contracts.auth import AuthContext
 from conversational_engine.contracts.common import (
     ClarificationBlock,
@@ -11,6 +12,7 @@ from conversational_engine.contracts.common import (
     WorkflowStatus,
 )
 from conversational_engine.orchestrator.service import OrchestratorOutcome
+from conversational_engine.runtime.service import AgentRuntimeService
 from conversational_engine.runtime.renderer import render_approval_pending, render_navigation_blocks, render_tool_result
 from conversational_engine.runtime.state_update import build_post_action_blocks, mark_task_status
 from conversational_engine.tools.catalog import SemanticToolCatalog
@@ -19,8 +21,16 @@ logger = logging.getLogger(__name__)
 
 
 class RuntimeDecisionHandler:
-    def __init__(self, backend_client: BackendClient) -> None:
+    def __init__(
+        self,
+        backend_client: BackendClient,
+        *,
+        audit_service: AuditService | None = None,
+        runtime_service: AgentRuntimeService | None = None,
+    ) -> None:
         self._backend_client = backend_client
+        self._audit_service = audit_service
+        self._runtime_service = runtime_service
 
     @staticmethod
     def _restore_pending_approval_state(memory: dict[str, object]) -> tuple[str, dict[str, object]]:
@@ -82,6 +92,7 @@ class RuntimeDecisionHandler:
                         approval_id=approval_id,
                         tool_name=restored_tool_name,
                         tool_arguments=restored_payload,
+                        actor=auth.email,
                     ),
                     status=WorkflowStatus.AWAITING_APPROVAL,
                     current_task='awaiting_approval',
@@ -157,6 +168,7 @@ class RuntimeDecisionHandler:
                 'workflowId': str(workflow_id),
                 'summary': str(memory.get('summary') or tool_name),
                 'reason': str(memory.get('approvalReason') or 'Approval required by policy.'),
+                'requestedBy': auth.email,
                 'preview': memory.get('preview') if isinstance(memory.get('preview'), dict) else {},
                 'executionPayload': execution_payload,
             }
@@ -190,6 +202,20 @@ class RuntimeDecisionHandler:
                     extracted_entities=memory,
                     missing_fields=[],
                 )
+            await self._record_audit_event(
+                auth=auth,
+                conversation_id=str(conversation_id),
+                workflow_id=str(workflow_id),
+                approval_id=str(approval.id),
+                event_type='approval_updated' if is_pending_approval_update else 'approval_created',
+                tool_name=tool_name,
+                payload={
+                    'actionType': tool_name,
+                    'summary': str(memory.get('summary') or tool_name),
+                    'status': approval.status,
+                    'executionPayload': execution_payload,
+                },
+            )
             memory['activeApprovalId'] = str(approval.id)
             memory['activeApprovalStatus'] = approval.status
             memory.pop('_pendingApprovalUpdateOriginal', None)
@@ -200,6 +226,7 @@ class RuntimeDecisionHandler:
                     approval_id=approval.id,
                     tool_name=tool_name,
                     tool_arguments=execution_payload,
+                    actor=auth.email,
                 ),
                 status=WorkflowStatus.AWAITING_APPROVAL,
                 current_task='awaiting_approval',
@@ -210,7 +237,8 @@ class RuntimeDecisionHandler:
 
         catalog = SemanticToolCatalog(backend=self._backend_client, auth=auth)
         try:
-            result = await catalog.invoke(tool_name, execution_payload)
+            with idempotency_scope(f'confirmation:{workflow_id}:{tool_name}'):
+                result = await catalog.invoke(tool_name, execution_payload)
         except Exception:
             logger.exception('Failed to execute runtime confirmation tool %s', tool_name)
             return OrchestratorOutcome(
@@ -230,29 +258,63 @@ class RuntimeDecisionHandler:
         memory.pop('activeApprovalStatus', None)
         memory.pop('_pendingApprovalUpdateOriginal', None)
         memory.pop('_approvalOperation', None)
-        try:
-            await self._backend_client.record_audit_event(
-                access_token=auth.access_token or '',
-                tenant_id=auth.tenant_id,
-                payload={
-                    'conversationId': str(conversation_id),
-                    'workflowId': str(workflow_id),
-                    'approvalRequestId': str(active_approval_id) if isinstance(active_approval_id, str) and active_approval_id else None,
-                    'eventType': 'execution_result',
-                    'payload': {
-                        'status': 'success',
-                        'toolName': tool_name,
-                        'actionType': tool_name,
-                        'summary': str(memory.get('summary') or tool_name),
-                        'executionPayload': execution_payload,
-                        'result': result,
-                    },
-                },
+        next_entities = AgentRuntimeService._merge_context_from_tool_interaction(
+            current_entities=memory,
+            tool_name=tool_name,
+            tool_arguments=execution_payload,
+            tool_result=result,
+        )
+        await self._record_audit_event(
+            auth=auth,
+            conversation_id=str(conversation_id),
+            workflow_id=str(workflow_id),
+            approval_id=str(active_approval_id) if isinstance(active_approval_id, str) and active_approval_id else None,
+            event_type='tool_executed',
+            tool_name=tool_name,
+            payload={
+                'actionType': tool_name,
+                'summary': str(memory.get('summary') or tool_name),
+                'executionPayload': execution_payload,
+                'result': result,
+            },
+        )
+        compound_queue = next_entities.get('compoundQueue')
+        if isinstance(compound_queue, list) and compound_queue and self._runtime_service is not None:
+            remaining_queue = [item for item in compound_queue[1:] if isinstance(item, str) and item.strip()]
+            chained_entities = dict(next_entities)
+            if remaining_queue:
+                chained_entities['compoundQueue'] = remaining_queue
+            else:
+                chained_entities.pop('compoundQueue', None)
+            chained_outcome = await self._runtime_service.execute(
+                auth=auth,
+                conversation_id=conversation_id,
+                workflow_id=workflow_id,
+                user_message=str(compound_queue[0]),
+                extracted_entities=chained_entities,
+                recent_messages=[],
+                workflow_status=WorkflowStatus.COMPLETED,
+                emit=lambda *_args, **_kwargs: None,
+                run_id=uuid4(),
             )
-        except Exception:
-            logger.exception('Failed to persist execution audit event for workflow %s', workflow_id)
+            return OrchestratorOutcome(
+                blocks=[
+                    *render_tool_result(
+                        'Confirmation recorded and the requested action has been executed.',
+                        tool_name,
+                        result,
+                    ),
+                    *chained_outcome.blocks,
+                ],
+                status=chained_outcome.status,
+                current_task=chained_outcome.current_task,
+                extracted_entities=chained_outcome.extracted_entities,
+                missing_fields=chained_outcome.missing_fields,
+                active_preview_id=chained_outcome.active_preview_id,
+                active_approval_id=chained_outcome.active_approval_id,
+            )
         post_action_blocks = render_navigation_blocks(build_post_action_blocks(_post_actions_from_memory(memory)))
-        next_entities = mark_task_status(memory, 'completed', clear_post_actions=True)
+        next_entities = mark_task_status(next_entities, 'completed', clear_post_actions=True)
         return OrchestratorOutcome(
             blocks=[
                 *render_tool_result(
@@ -267,6 +329,34 @@ class RuntimeDecisionHandler:
             extracted_entities=next_entities,
             missing_fields=[],
         )
+
+    async def _record_audit_event(
+        self,
+        *,
+        auth: AuthContext,
+        conversation_id: str,
+        workflow_id: str,
+        event_type: str,
+        payload: dict[str, object],
+        tool_name: str | None = None,
+        approval_id: str | None = None,
+    ) -> None:
+        if self._audit_service is None:
+            return
+        try:
+            await self._audit_service.record(
+                tenant_id=auth.tenant_id,
+                user_id=auth.id,
+                actor_email=auth.email,
+                event_type=event_type,
+                conversation_id=conversation_id,
+                workflow_id=workflow_id,
+                approval_id=approval_id,
+                tool_name=tool_name,
+                payload=payload,
+            )
+        except Exception:
+            logger.exception('Failed to persist runtime decision audit event %s', event_type)
 
 
 def _post_actions_from_memory(memory: dict[str, object]) -> list[dict[str, object]]:

--- a/conversational-engine/src/conversational_engine/conversations/runtime_runner.py
+++ b/conversational-engine/src/conversational_engine/conversations/runtime_runner.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator, Callable
 from conversational_engine.ai.attachments import S3AttachmentService
 from conversational_engine.ai.redis_cache import RedisActiveStateCache
 from conversational_engine.ai.repository import AIRepository
+from conversational_engine.audit.service import AuditService
 from conversational_engine.config.settings import Settings
 from conversational_engine.contracts.auth import AuthContext
 from conversational_engine.contracts.common import ConversationDetail, MessageRole, TextBlock, WorkflowState, WorkflowStatus
@@ -25,6 +26,7 @@ class ConversationRuntimeRunner:
         attachment_service: S3AttachmentService,
         redis_cache: RedisActiveStateCache,
         settings: Settings,
+        audit_service: AuditService | None = None,
     ) -> None:
         self._repository = repository
         self._runtime_service = runtime_service
@@ -32,6 +34,7 @@ class ConversationRuntimeRunner:
         self._attachment_service = attachment_service
         self._redis_cache = redis_cache
         self._settings = settings
+        self._audit_service = audit_service
 
     async def stream_run(
         self,
@@ -113,6 +116,23 @@ class ConversationRuntimeRunner:
             raw_text=content_with_attachments,
             attachments=attachment_payload.attachment_refs,
         )
+        if self._audit_service is not None:
+            try:
+                await self._audit_service.record(
+                    tenant_id=auth.tenant_id,
+                    user_id=auth.id,
+                    actor_email=auth.email,
+                    event_type='incoming_message',
+                    conversation_id=str(conversation.id),
+                    workflow_id=str(workflow.id),
+                    payload={
+                        'content': content,
+                        'attachmentIds': attachment_ids,
+                        'inlineAttachmentCount': len(inline_attachments),
+                    },
+                )
+            except Exception:
+                pass
         run = await self._repository.create_run(
             tenant_id=auth.tenant_id,
             conversation_id=conversation.id,

--- a/conversational-engine/src/conversational_engine/conversations/service.py
+++ b/conversational-engine/src/conversational_engine/conversations/service.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
+from fastapi import HTTPException, status
+
 from conversational_engine.ai.attachments import S3AttachmentService
 from conversational_engine.ai.redis_cache import RedisActiveStateCache
 from conversational_engine.ai.repository import AIRepository
+from conversational_engine.audit.service import AuditService
 from conversational_engine.clients.backend import BackendClient
 from conversational_engine.config.settings import Settings
 from conversational_engine.contracts.api import (
@@ -32,12 +35,14 @@ class ConversationService:
         repository: AIRepository,
         backend_client: BackendClient,
         runtime_service: AgentRuntimeService,
+        audit_service: AuditService | None,
         attachment_service: S3AttachmentService,
         redis_cache: RedisActiveStateCache,
         settings: Settings,
     ) -> None:
         self._repository = repository
         self._backend_client = backend_client
+        self._audit_service = audit_service
         self._attachment_service = attachment_service
         self._redis_cache = redis_cache
         self._settings = settings
@@ -49,9 +54,14 @@ class ConversationService:
             attachment_service=attachment_service,
             redis_cache=redis_cache,
             settings=settings,
+            audit_service=audit_service,
         )
-        self._approval_executor = RuntimeApprovalExecutor(backend_client)
-        self._runtime_decision_handler = RuntimeDecisionHandler(backend_client)
+        self._approval_executor = RuntimeApprovalExecutor(backend_client, audit_service=audit_service)
+        self._runtime_decision_handler = RuntimeDecisionHandler(
+            backend_client,
+            audit_service=audit_service,
+            runtime_service=runtime_service,
+        )
 
     async def list_conversations(self, auth: AuthContext) -> ConversationListResponse:
         return ConversationListResponse(items=await self._repository.list_conversations(auth.tenant_id))
@@ -103,6 +113,7 @@ class ConversationService:
         )
         if result is None:
             return None
+        self._ensure_conversation_access(auth, result.conversation)
         safe_workflow = self._outcome_store.sanitize_workflow(result.workflow)
         message_page = MessagePageInfo(
             next_cursor_created_at=result.page.next_cursor_created_at.isoformat()
@@ -133,6 +144,7 @@ class ConversationService:
         )
         if current is None or current.workflow is None:
             return None
+        self._ensure_conversation_access(auth, current.conversation)
         await self._runtime_runner.run_message(
             auth=auth,
             conversation=current.conversation,
@@ -170,6 +182,7 @@ class ConversationService:
             )
 
         conversation, _existing_workflow = conversation_lookup
+        self._ensure_conversation_access(auth, conversation)
         if workflow.extracted_entities.get('_workflowEngine') == 'runtime':
             outcome = await self._runtime_decision_handler.apply(
                 auth=auth,
@@ -203,6 +216,22 @@ class ConversationService:
         approval_id: UUID,
         approve: bool,
     ) -> ApprovalDecisionResponse:
+        approval = await self._backend_client.get_approval_request(
+            access_token=auth.access_token or '',
+            tenant_id=auth.tenant_id,
+            approval_id=str(approval_id),
+        )
+
+        if approval.conversation_id:
+            current = await self._repository.get_conversation(
+                auth.tenant_id,
+                approval.conversation_id,
+                message_limit=self._settings.chat_recent_message_limit,
+            )
+            if current is None:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Conversation not found.')
+            self._ensure_conversation_access(auth, current.conversation)
+
         result = await self._backend_client.decide_approval(
             access_token=auth.access_token or '',
             tenant_id=auth.tenant_id,
@@ -214,6 +243,26 @@ class ConversationService:
             tenant_id=auth.tenant_id,
             approval_id=str(approval_id),
         )
+        if not approve and self._audit_service is not None:
+            try:
+                await self._audit_service.record(
+                    tenant_id=auth.tenant_id,
+                    user_id=auth.id,
+                    actor_email=auth.email,
+                    event_type='approval_rejected',
+                    conversation_id=str(approval.conversation_id) if approval.conversation_id else None,
+                    workflow_id=str(approval.workflow_id) if approval.workflow_id else None,
+                    approval_id=str(approval.id),
+                    tool_name=approval.tool_name,
+                    payload={
+                        'actionType': approval.action_type,
+                        'summary': approval.summary,
+                        'status': approval.status,
+                        'executionPayload': approval.execution_payload,
+                    },
+                )
+            except Exception:
+                pass
 
         if approval.workflow_id and approval.conversation_id:
             workflow = await self._repository.find_workflow_by_id(auth.tenant_id, approval.workflow_id)
@@ -233,3 +282,16 @@ class ConversationService:
                 )
 
         return result
+
+    def _ensure_conversation_access(self, auth: AuthContext, conversation) -> None:
+        owner_id = getattr(conversation, 'created_by', None)
+        if owner_id is None or owner_id == auth.id or self._is_admin(auth):
+            return
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail='You do not have access to this conversation.',
+        )
+
+    @staticmethod
+    def _is_admin(auth: AuthContext) -> bool:
+        return any('admin' in permission.lower() for permission in auth.permissions)

--- a/conversational-engine/src/conversational_engine/db/mappers.py
+++ b/conversational-engine/src/conversational_engine/db/mappers.py
@@ -34,6 +34,7 @@ def conversation_detail_from_row(row: dict[str, object], *, id_field: str = 'id'
     return ConversationDetail(
         id=row[id_field],
         title=row['title'],
+        created_by=row.get('created_by'),
         created_at=row['created_at'],
         updated_at=row['updated_at'],
     )

--- a/conversational-engine/src/conversational_engine/db/repository.py
+++ b/conversational-engine/src/conversational_engine/db/repository.py
@@ -211,7 +211,7 @@ class EngineRepository:
         with self._connection() as conn, conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT id, title, created_at, updated_at
+                SELECT id, title, created_by, created_at, updated_at
                 FROM ai_conversations
                 WHERE tenant_id = %s AND id = %s
                 """,
@@ -300,6 +300,7 @@ class EngineRepository:
                 SELECT
                   c.id AS conversation_id,
                   c.title,
+                  c.created_by,
                   c.created_at,
                   c.updated_at,
                   w.id,

--- a/conversational-engine/src/conversational_engine/orchestrator/intents.py
+++ b/conversational-engine/src/conversational_engine/orchestrator/intents.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 from conversational_engine.contracts.common import PendingActionType
 
 from .parsing import matches_intent_pattern, normalize_text
@@ -11,15 +13,37 @@ WRITE_PENDING_ACTIONS = [
     PendingActionType.EDIT.value,
     PendingActionType.SUBMIT_FOR_APPROVAL.value,
 ]
+INVENTORY_KEYWORDS = (
+    'stock',
+    'inventory',
+    'product',
+    'sku',
+    'purchase order',
+    'po',
+    'supplier',
+    'customer',
+    'invoice',
+    'sales order',
+    'warehouse',
+    'location',
+    'report',
+    'movement',
+    'receipt',
+    'transfer',
+    'adjust',
+    'category',
+    'brand',
+    'price',
+)
+PENDING_TASK_TTL = timedelta(minutes=30)
 
 
 def classify_intent(message: str, memory: dict[str, object]) -> str:
     normalized = normalize_text(message)
+    pending_task = _active_pending_task(memory)
 
-    if memory.get('intent') and any(
-        word in normalized for word in ['yes', 'update', 'change', 'it', 'that', 'for', 'with', 'at']
-    ):
-        return str(memory['intent'])
+    if pending_task and _looks_like_pending_follow_up(normalized):
+        return str(pending_task['intent'])
 
     if matches_intent_pattern(
         message,
@@ -106,4 +130,46 @@ def classify_intent(message: str, memory: dict[str, object]) -> str:
         return 'stock_query'
     if any(phrase in normalized for phrase in ['purchase order', 'po ']):
         return 'reporting_query'
+    if pending_task:
+        return str(pending_task['intent'])
+    if _is_off_topic(normalized):
+        return 'off_topic'
     return str(memory.get('intent') or 'navigation_help')
+
+
+def _is_off_topic(normalized: str) -> bool:
+    if any(keyword in normalized for keyword in INVENTORY_KEYWORDS):
+        return False
+    tokens = normalized.split()
+    return len(tokens) > 3
+
+
+def _active_pending_task(memory: dict[str, object]) -> dict[str, object] | None:
+    raw = memory.get('pendingTask')
+    if not isinstance(raw, dict):
+        raw = memory.get('pending_task')
+    if not isinstance(raw, dict):
+        return None
+    updated_at = raw.get('updatedAt')
+    if not isinstance(updated_at, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(updated_at.replace('Z', '+00:00'))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    if datetime.now(UTC) - parsed > PENDING_TASK_TTL:
+        return None
+    if not raw.get('intent'):
+        return None
+    return raw
+
+
+def _looks_like_pending_follow_up(normalized: str) -> bool:
+    if not normalized or normalized.endswith('?'):
+        return False
+    tokens = normalized.split()
+    if len(tokens) <= 4:
+        return True
+    return ':' in normalized

--- a/conversational-engine/src/conversational_engine/orchestrator/service.py
+++ b/conversational-engine/src/conversational_engine/orchestrator/service.py
@@ -33,6 +33,7 @@ from conversational_engine.contracts.common import (
 )
 from conversational_engine.providers.base import IntentClassifier
 from conversational_engine.retrieval.service import RetrievalService
+from conversational_engine.utils.time import utc_now
 from conversational_engine.orchestrator.entities import (
     extract_inventory_entities,
     extract_po_entities,
@@ -149,6 +150,18 @@ class OrchestratorService:
 
         intent = await self._classify_intent_with_providers(user_message, memory, workflow)
         memory['intent'] = intent
+        if intent == 'off_topic':
+            return OrchestratorOutcome(
+                blocks=[
+                    TextBlock(
+                        content='I can help with inventory, products, purchasing, sales orders, suppliers, customers, and reports.'
+                    )
+                ],
+                status=WorkflowStatus.COMPLETED,
+                current_task='off_topic_redirected',
+                extracted_entities=memory,
+                missing_fields=[],
+            )
         await self._audit(
             auth,
             conversation_id=str(conversation.id),
@@ -220,6 +233,7 @@ class OrchestratorService:
         memory.update(result.memory_updates or {})
 
         if result.next_action == 'return_read_result':
+            self._clear_pending_task(memory)
             return OrchestratorOutcome(
                 blocks=result.blocks or [TextBlock(content='Done.')],
                 status=WorkflowStatus.IDLE,
@@ -235,6 +249,7 @@ class OrchestratorService:
             prompt = result.follow_up_prompt or self._clarification_prompt(intent, memory, missing_fields)
             memory.pop('_pendingActions', None)
             memory.pop('_pendingPrompt', None)
+            self._set_pending_task(memory, intent=intent, missing_fields=missing_fields)
             await self._audit(
                 auth,
                 conversation_id=str(conversation.id),
@@ -278,8 +293,14 @@ class OrchestratorService:
             WorkflowStatus.AWAITING_CONFIRMATION,
             WorkflowStatus.AWAITING_APPROVAL,
         }:
-            if memory.get('intent') and 'new chat' not in normalized and 'start over' not in normalized:
-                return str(memory['intent'])
+            pending_task = memory.get('pendingTask')
+            if (
+                isinstance(pending_task, dict)
+                and pending_task.get('intent')
+                and 'new chat' not in normalized
+                and 'start over' not in normalized
+            ):
+                return str(pending_task['intent'])
 
         intents = [
             'stock_query',
@@ -343,6 +364,7 @@ class OrchestratorService:
             memory['requesterAccessToken'] = auth.access_token
         memory['_pendingActions'] = WRITE_PENDING_ACTIONS
         memory['_pendingPrompt'] = 'Review the preview, then confirm or submit it for approval.'
+        self._set_pending_task(memory, intent=intent, missing_fields=[])
 
         await self._audit(
             auth,
@@ -395,6 +417,7 @@ class OrchestratorService:
             memory.pop('requesterAccessToken', None)
             memory.pop('_pendingActions', None)
             memory.pop('_pendingPrompt', None)
+            self._clear_pending_task(memory)
             await self._audit(
                 auth,
                 conversation_id=str(conversation.id),
@@ -420,6 +443,7 @@ class OrchestratorService:
         if decision == PendingActionType.EDIT.value:
             memory.pop('_pendingActions', None)
             memory.pop('_pendingPrompt', None)
+            self._set_pending_task(memory, intent=str(memory.get('intent') or action_type), missing_fields=[])
             return OrchestratorOutcome(
                 blocks=[
                     ClarificationBlock(
@@ -1448,3 +1472,18 @@ class OrchestratorService:
             )
         except Exception:
             return
+
+    @staticmethod
+    def _set_pending_task(memory: dict[str, object], *, intent: str, missing_fields: list[str]) -> None:
+        entity_snapshot = {key: value for key, value in memory.items() if key not in {'pendingTask', 'pending_task'}}
+        memory['pendingTask'] = {
+            'intent': intent,
+            'entities': entity_snapshot,
+            'missingFields': list(missing_fields),
+            'updatedAt': utc_now().isoformat(),
+        }
+
+    @staticmethod
+    def _clear_pending_task(memory: dict[str, object]) -> None:
+        memory.pop('pendingTask', None)
+        memory.pop('pending_task', None)

--- a/conversational-engine/src/conversational_engine/providers/gemini_runtime.py
+++ b/conversational-engine/src/conversational_engine/providers/gemini_runtime.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import json
 from typing import Any
 
 import httpx
 
 from conversational_engine.providers.runtime import ProviderMessage, ProviderResponse, RuntimeProvider
+from conversational_engine.utils.json_parsing import parse_json_object
 
 
 class GeminiRuntimeProvider(RuntimeProvider):
@@ -95,12 +95,7 @@ class GeminiRuntimeProvider(RuntimeProvider):
             response.raise_for_status()
             data = response.json()
         raw = self._extract_text(data if isinstance(data, dict) else {})
-        try:
-            parsed = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise RuntimeError(f'gemini returned invalid JSON: {exc}') from exc
-        if not isinstance(parsed, dict):
-            raise RuntimeError('gemini returned a non-object JSON payload')
+        parsed = parse_json_object(raw, source='gemini')
         return ProviderResponse(
             provider_name=self.name,
             model_name=model,

--- a/conversational-engine/src/conversational_engine/providers/openai_compatible.py
+++ b/conversational-engine/src/conversational_engine/providers/openai_compatible.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from typing import Any
 
 import httpx
@@ -12,6 +11,7 @@ from conversational_engine.providers.base import (
     IntentClassifier,
     ProviderMessage,
 )
+from conversational_engine.utils.json_parsing import parse_json_object
 
 
 class OpenAICompatibleChatProvider(ChatProvider):
@@ -82,13 +82,7 @@ class OpenAICompatibleChatProvider(ChatProvider):
         raw = data.get('choices', [{}])[0].get('message', {}).get('content')
         if not isinstance(raw, str) or not raw.strip():
             raise RuntimeError('LLM returned empty JSON content')
-        try:
-            parsed = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise RuntimeError(f'LLM returned invalid JSON: {exc}') from exc
-        if not isinstance(parsed, dict):
-            raise RuntimeError('LLM JSON output was not an object')
-        return parsed
+        return parse_json_object(raw, source='LLM')
 
 
 class OpenAICompatibleEmbeddingsProvider(EmbeddingsProvider):

--- a/conversational-engine/src/conversational_engine/providers/openai_runtime.py
+++ b/conversational-engine/src/conversational_engine/providers/openai_runtime.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import json
 from typing import Any
 
 import httpx
 
 from conversational_engine.providers.runtime import ProviderMessage, ProviderResponse, RuntimeProvider
+from conversational_engine.utils.json_parsing import parse_json_object
 
 
 class OpenAICompatibleRuntimeProvider(RuntimeProvider):
@@ -115,12 +115,7 @@ class OpenAICompatibleRuntimeProvider(RuntimeProvider):
         if not isinstance(raw, str) or not raw.strip():
             raise RuntimeError(f'{self.name} returned an empty JSON response')
 
-        try:
-            parsed = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise RuntimeError(f'{self.name} returned invalid JSON: {exc}') from exc
-        if not isinstance(parsed, dict):
-            raise RuntimeError(f'{self.name} returned a non-object JSON payload')
+        parsed = parse_json_object(raw, source=self.name)
 
         return ProviderResponse(
             provider_name=self.name,

--- a/conversational-engine/src/conversational_engine/retrieval/service.py
+++ b/conversational-engine/src/conversational_engine/retrieval/service.py
@@ -30,7 +30,10 @@ def _embed(text: str, dimensions: int = 64) -> list[float]:
 
 
 def _cosine(left: list[float], right: list[float]) -> float:
-    return sum(a * b for a, b in zip(left, right, strict=False))
+    try:
+        return sum(a * b for a, b in zip(left, right, strict=True))
+    except ValueError as exc:
+        raise ValueError('Embedding vectors must have the same length for cosine similarity.') from exc
 
 
 def _chunks(content: str) -> list[str]:

--- a/conversational-engine/src/conversational_engine/runtime/commerce_matching.py
+++ b/conversational-engine/src/conversational_engine/runtime/commerce_matching.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import re
+
+from conversational_engine.clients.backend import BackendClient
+from conversational_engine.contracts.auth import AuthContext
+
+SIZE_LABELS = {'XXS', 'XS', 'S', 'M', 'L', 'XL', 'XXL', 'XXXL'} | {str(size) for size in range(2, 31, 2)}
+
+
+def normalize_text(value: str) -> str:
+    return ' '.join(''.join(character.lower() if character.isalnum() else ' ' for character in value).split())
+
+
+def normalized_tokens(value: str) -> set[str]:
+    return {token for token in normalize_text(value).split() if token}
+
+
+def parse_size_labels(text: str) -> list[str]:
+    labels: list[str] = []
+    for token in re.findall(r'\b[A-Za-z0-9]+\b', text.upper()):
+        if token in SIZE_LABELS and token not in labels:
+            labels.append(token)
+    return labels
+
+
+async def match_location(
+    backend_client: BackendClient,
+    auth: AuthContext,
+    message: str,
+    *,
+    qualifier: str | None = None,
+) -> dict[str, str] | None:
+    text = message
+    if qualifier:
+        qualifier_match = re.search(rf'{qualifier}\s+([A-Za-z0-9 \-]+)', message, re.IGNORECASE)
+        if qualifier_match:
+            text = qualifier_match.group(1)
+    locations = await backend_client.list_locations(auth.access_token or '', auth.tenant_id)
+    target = normalize_text(text)
+    target_tokens = normalized_tokens(text)
+    for location in locations:
+        name = str(location.get('name') or '')
+        code = str(location.get('code') or '')
+        normalized_name = normalize_text(name)
+        normalized_code = normalize_text(code)
+        name_tokens = normalized_tokens(name)
+        code_tokens = normalized_tokens(code)
+        if (
+            normalized_name in target
+            or normalized_code in target
+            or target in normalized_name
+            or target in normalized_code
+            or bool(target_tokens & name_tokens)
+            or bool(target_tokens & code_tokens)
+        ):
+            return {'id': str(location['id']), 'label': f'{name} ({code})'}
+    return None
+
+
+async def match_supplier(
+    backend_client: BackendClient,
+    auth: AuthContext,
+    message: str,
+) -> dict[str, str] | None:
+    suppliers = await backend_client.list_suppliers(auth.access_token or '', auth.tenant_id)
+    target = normalize_text(message)
+    for supplier in suppliers:
+        name = str(supplier.get('name') or '')
+        if normalize_text(name) in target:
+            return {'id': str(supplier['id']), 'label': name}
+    return None
+
+
+async def match_customer(
+    backend_client: BackendClient,
+    auth: AuthContext,
+    message: str,
+) -> dict[str, str] | None:
+    customers = await backend_client.list_customers(auth.access_token or '', auth.tenant_id)
+    target = normalize_text(message)
+    for customer in customers:
+        name = str(customer.get('name') or '')
+        if normalize_text(name) in target:
+            return {'id': str(customer['id']), 'label': name}
+    return None
+
+
+async def resolve_size_reference(
+    backend_client: BackendClient,
+    auth: AuthContext,
+    *,
+    sku_code: str,
+    size_label: str,
+) -> dict[str, object] | None:
+    if not sku_code or not size_label:
+        return None
+    sku_matches = await backend_client.search_skus(auth.access_token or '', auth.tenant_id, sku_code)
+    exact = None
+    for candidate in sku_matches:
+        code = str(candidate.get('sku_code') or '')
+        if code.upper() == sku_code.upper():
+            exact = candidate
+            break
+    candidate = exact or (sku_matches[0] if sku_matches else None)
+    if not isinstance(candidate, dict):
+        return None
+
+    product = await backend_client.get_product(
+        auth.access_token or '',
+        auth.tenant_id,
+        str(candidate['product_id']),
+    )
+    skus = product.get('skus', []) if isinstance(product, dict) else []
+    sizes = product.get('sizes', []) if isinstance(product, dict) else []
+
+    existing_sku_id: str | None = None
+    for sku in skus:
+        if not isinstance(sku, dict):
+            continue
+        if str(sku.get('sku_code') or '').upper() == sku_code.upper():
+            existing_sku_id = str(sku['id'])
+            break
+
+    for size in sizes:
+        if not isinstance(size, dict):
+            continue
+        if existing_sku_id and str(size.get('sku_id')) != existing_sku_id:
+            continue
+        if str(size.get('size_label') or '').upper() != size_label.upper():
+            continue
+        return {
+            'sizeId': str(size['id']),
+            'sizeLabel': str(size['size_label']),
+            'skuCode': sku_code.upper(),
+            'existingSkuId': existing_sku_id,
+            'existingSizeId': str(size['id']),
+        }
+    return {
+        'skuCode': sku_code.upper(),
+        'sizeLabel': size_label.upper(),
+        'existingSkuId': existing_sku_id,
+    }
+
+
+async def parse_po_lines(
+    backend_client: BackendClient,
+    auth: AuthContext,
+    message: str,
+    *,
+    po_id: str,
+    allow_missing_cost: bool,
+) -> list[dict[str, object]]:
+    segments = [segment.strip() for segment in re.split(r'[,\n;]+', message) if segment.strip()]
+    if not segments:
+        return []
+
+    po_cost_map: dict[tuple[str, str], int] = {}
+    if allow_missing_cost and po_id:
+        po_detail = await backend_client.get_po(auth.access_token or '', auth.tenant_id, po_id)
+        for line in po_detail.get('lines', []):
+            if not isinstance(line, dict):
+                continue
+            sku = str(line.get('sku') or '')
+            if '-' not in sku:
+                continue
+            sku_code, size_label = sku.rsplit('-', 1)
+            po_cost_map[(sku_code.upper(), size_label.upper())] = int(line.get('unitCost') or 0)
+
+    lines: list[dict[str, object]] = []
+    sized_pattern = re.compile(
+        r'(?P<sku>[A-Za-z0-9-]+)\s*/\s*(?P<size>[A-Za-z0-9]+)\s*x(?P<qty>\d+)(?:\s*@(?P<cost>\d+))?',
+        re.IGNORECASE,
+    )
+    bare_pattern = re.compile(
+        r'(?P<sku>[A-Za-z0-9-]+)\s+(?P<qty>\d+)\s*(?:items?|units?|pcs?)\b(?:\s*@(?P<cost>\d+))?',
+        re.IGNORECASE,
+    )
+    for segment in segments:
+        sized_match = sized_pattern.search(segment)
+        if sized_match:
+            size_ref = await resolve_size_reference(
+                backend_client,
+                auth,
+                sku_code=sized_match.group('sku').upper(),
+                size_label=sized_match.group('size').upper(),
+            )
+            if not size_ref or not size_ref.get('sizeId'):
+                continue
+            cost = sized_match.group('cost')
+            if cost is None and allow_missing_cost:
+                remembered = po_cost_map.get((sized_match.group('sku').upper(), sized_match.group('size').upper()))
+                if remembered is not None:
+                    cost = str(remembered)
+            line: dict[str, object] = {
+                'sizeId': size_ref['sizeId'],
+                'qty': int(sized_match.group('qty')),
+            }
+            if cost is not None:
+                line['unitCost'] = int(cost)
+            lines.append(line)
+            continue
+
+        bare_match = bare_pattern.search(segment)
+        if not bare_match:
+            continue
+        line = {
+            'productName': bare_match.group('sku').upper(),
+            'qty': int(bare_match.group('qty')),
+        }
+        if bare_match.group('cost') is not None:
+            line['unitCost'] = int(bare_match.group('cost'))
+        lines.append(line)
+
+    if lines:
+        return lines
+
+    qty_match = re.search(r'\b(\d+)\s*(?:items?|units?|pcs?)\b', message, re.IGNORECASE)
+    if not qty_match:
+        return []
+
+    style_match = re.search(r'\b[A-Za-z]{2,}[A-Za-z0-9]*-\d{2,}\b', message)
+    if style_match:
+        fallback_line: dict[str, object] = {
+            'productName': style_match.group(0).upper(),
+            'qty': int(qty_match.group(1)),
+        }
+        cost_match = re.search(r'@\s*(\d+)\b', message)
+        if cost_match:
+            fallback_line['unitCost'] = int(cost_match.group(1))
+        return [fallback_line]
+
+    return lines
+
+
+async def parse_sales_lines(
+    backend_client: BackendClient,
+    auth: AuthContext,
+    message: str,
+    *,
+    invoice_id: str,
+) -> list[dict[str, object]]:
+    del invoice_id
+    segments = [segment.strip() for segment in re.split(r'[,\n;]+', message) if segment.strip()]
+    if not segments:
+        return []
+
+    lines: list[dict[str, object]] = []
+    pattern = re.compile(
+        r'(?P<sku>[A-Za-z0-9-]+)\s*/\s*(?P<size>[A-Za-z0-9]+)\s*x(?P<qty>\d+)(?:\s*@(?P<price>\d+))?',
+        re.IGNORECASE,
+    )
+    for segment in segments:
+        match = pattern.search(segment)
+        if not match or match.group('price') is None:
+            continue
+        size_ref = await resolve_size_reference(
+            backend_client,
+            auth,
+            sku_code=match.group('sku').upper(),
+            size_label=match.group('size').upper(),
+        )
+        if not size_ref or not size_ref.get('sizeId'):
+            continue
+        lines.append(
+            {
+                'sizeId': size_ref['sizeId'],
+                'qty': int(match.group('qty')),
+                'unitPrice': int(match.group('price')),
+            }
+        )
+    return lines

--- a/conversational-engine/src/conversational_engine/runtime/renderer.py
+++ b/conversational-engine/src/conversational_engine/runtime/renderer.py
@@ -69,6 +69,7 @@ def render_approval_pending(
     approval_id: UUID,
     tool_name: str,
     tool_arguments: dict[str, Any],
+    actor: str,
 ) -> list[MessageBlock]:
     entities = [
         PreviewEntity(label=key, value=str(value))
@@ -79,7 +80,7 @@ def render_approval_pending(
         TextBlock(content=message),
         PreviewBlock(
             action_type=tool_name.replace('.', ' ').title(),
-            actor='AI runtime',
+            actor=actor,
             entities=entities,
             warnings=[],
             approval_required=True,
@@ -100,6 +101,8 @@ def render_confirmation_required(
     tool_arguments: dict[str, Any],
     approval_required: bool,
     confirmation_prompt: str,
+    actor: str,
+    warnings: list[str] | None = None,
 ) -> list[MessageBlock]:
     entities = [
         PreviewEntity(label=key, value=str(value))
@@ -110,9 +113,9 @@ def render_confirmation_required(
         TextBlock(content=message),
         PreviewBlock(
             action_type=tool_name.replace('.', ' ').title(),
-            actor='AI runtime',
+            actor=actor,
             entities=entities,
-            warnings=[],
+            warnings=list(warnings or []),
             approval_required=approval_required,
             next_step=confirmation_prompt,
         ),

--- a/conversational-engine/src/conversational_engine/runtime/service.py
+++ b/conversational-engine/src/conversational_engine/runtime/service.py
@@ -54,6 +54,8 @@ EventSink = Callable[[str, dict[str, object]], None]
 logger = logging.getLogger(__name__)
 
 _WRITE_TOOL_ENTITY_FIELDS: dict[str, tuple[str, ...]] = {
+    'master.create_supplier': ('name', 'email', 'phone', 'address', 'status'),
+    'master.create_customer': ('name', 'email', 'phone', 'address', 'status'),
     'master.create_location': ('name', 'code', 'type', 'address', 'status'),
     'purchasing.cancel_po': ('poId',),
     'purchasing.close_po': ('poId',),
@@ -66,6 +68,8 @@ _WRITE_TOOL_ENTITY_FIELDS: dict[str, tuple[str, ...]] = {
     'sales.update_invoice': ('invoiceId', 'headerPatch', 'lines', 'lineOps'),
 }
 _WRITE_TOOL_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
+    'master.create_supplier': ('name',),
+    'master.create_customer': ('name',),
     'master.create_location': ('name', 'code', 'type'),
     'purchasing.cancel_po': ('poId',),
     'purchasing.close_po': ('poId',),
@@ -268,6 +272,43 @@ def _extract_invoice_reference(message: str) -> str | None:
     return None
 
 
+def _message_requests_same_details(message: str) -> bool:
+    normalized = ' '.join(message.strip().lower().split())
+    if normalized in {'yes', 'yeah', 'yep', 'same', 'again'}:
+        return True
+    return any(
+        phrase in normalized
+        for phrase in (
+            'same details',
+            'use same',
+            'same as previous',
+            'same as before',
+            'same as last order',
+            'same as previous order',
+        )
+    )
+
+
+def _extract_order_product_reference(message: str) -> str | None:
+    patterns = (
+        re.compile(
+            r'\b(?:purchase order|po|sales order|invoice|so)\s+for\s+(.+?)(?=\s+(?:from|to|at|with|for|qty|quantity|size|color|colour|@)\b|[.?!]|$)',
+            re.IGNORECASE,
+        ),
+        re.compile(
+            r'\bfor\s+(.+?)(?=\s+(?:from|to|at|with|qty|quantity|size|color|colour|@)\b|[.?!]|$)',
+            re.IGNORECASE,
+        ),
+    )
+    for pattern in patterns:
+        match = pattern.search(message)
+        if match:
+            candidate = str(match.group(1)).strip(' ,.;')
+            if candidate:
+                return candidate
+    return None
+
+
 _ORDINAL_LINE_INDEX: dict[str, int] = {
     '1st': 0,
     'first': 0,
@@ -287,11 +328,14 @@ _SIZE_LABEL_ALIASES: tuple[tuple[str, str], ...] = (
     ('xxs', 'XXS'),
     ('extra small', 'XS'),
     ('xs', 'XS'),
+    ('s', 'S'),
     ('small', 'S'),
     ('sm', 'S'),
+    ('m', 'M'),
     ('medium', 'M'),
     ('med', 'M'),
     ('md', 'M'),
+    ('l', 'L'),
     ('large', 'L'),
     ('lg', 'L'),
     ('extra large', 'XL'),
@@ -379,6 +423,129 @@ def _canonical_po_line_signature(line: dict[str, object]) -> tuple[str, int, int
         return (size_id, int(raw_qty), int(raw_cost))
     except (TypeError, ValueError):
         return None
+
+
+def _normalize_size_label(value: object) -> str | None:
+    raw = str(value or '').strip()
+    if not raw:
+        return None
+    lowered = raw.lower()
+    for alias, label in _SIZE_LABEL_ALIASES:
+        if lowered == alias:
+            return label
+    return raw.upper()
+
+
+def _extract_follow_up_quantity(message: str) -> int | None:
+    patterns = (
+        re.compile(r'\bx\s*(?P<qty>\d+)\b', re.IGNORECASE),
+        re.compile(r'(?:^|[\s,;])[-=]\s*(?P<qty>\d+)\b'),
+        re.compile(r'\bquantity\s*(?:is|to|=)?\s*(?P<qty>\d+)\b', re.IGNORECASE),
+        re.compile(r'\b(?P<qty>\d+)\s*(?:items?|units?|pcs?|pieces?)\b', re.IGNORECASE),
+    )
+    for pattern in patterns:
+        match = pattern.search(message)
+        if match:
+            return int(match.group('qty'))
+    return None
+
+
+def _extract_follow_up_unit_value(message: str) -> int | None:
+    patterns = (
+        re.compile(r'@\s*(?P<value>\d+)\b'),
+        re.compile(r'\b(?:unit\s+)?(?:cost|price)\s*(?:is|to|=|at)?\s*(?P<value>\d+)\b', re.IGNORECASE),
+    )
+    for pattern in patterns:
+        match = pattern.search(message)
+        if match:
+            return int(match.group('value'))
+    normalized = ' '.join(message.strip().split())
+    if re.fullmatch(r'\d+', normalized):
+        return int(normalized)
+    return None
+
+
+def _extract_follow_up_size_label(message: str, available_sizes: list[str]) -> str | None:
+    lowered = message.lower()
+    normalized_available = {_normalize_size_label(size) for size in available_sizes}
+    for alias, label in _SIZE_LABEL_ALIASES:
+        if label not in normalized_available:
+            continue
+        if re.search(rf'\b{re.escape(alias)}\b', lowered, re.IGNORECASE):
+            return label
+    return None
+
+
+def _extract_follow_up_color_name(message: str, available_colors: list[str]) -> str | None:
+    lowered = message.lower()
+    for color in available_colors:
+        normalized = str(color).strip()
+        if not normalized:
+            continue
+        if re.search(rf'\b{re.escape(normalized.lower())}\b', lowered, re.IGNORECASE):
+            return normalized
+    return None
+
+
+def _merge_single_line_patch(
+    existing_lines: object,
+    line_patch: dict[str, object],
+) -> list[dict[str, object]] | None:
+    if not line_patch:
+        return None
+    lines = [dict(line) for line in existing_lines if isinstance(line, dict)] if isinstance(existing_lines, list) else []
+    if not lines:
+        return [line_patch]
+    if len(lines) != 1:
+        return None
+    merged_line = dict(lines[0])
+    merged_line.update(line_patch)
+    return [merged_line]
+
+
+def _extract_grouped_variant_lines(
+    *,
+    message: str,
+    product_name: str,
+    available_colors: list[str],
+    available_sizes: list[str],
+    unit_cost: int | None,
+) -> list[dict[str, object]]:
+    clauses = [part.strip(' ,;') for part in re.split(r'[.\n;]+', message) if part.strip(' ,;')]
+    if not clauses:
+        return []
+
+    normalized_sizes = {_normalize_size_label(size) for size in available_sizes}
+    lines: list[dict[str, object]] = []
+    for clause in clauses:
+        color_name = _extract_follow_up_color_name(clause, available_colors)
+        quantity = _extract_follow_up_quantity(clause)
+        if not color_name or quantity is None:
+            continue
+
+        matched_sizes: list[str] = []
+        lowered = clause.lower()
+        for alias, label in _SIZE_LABEL_ALIASES:
+            if label not in normalized_sizes:
+                continue
+            if re.search(rf'\b{re.escape(alias)}\b', lowered, re.IGNORECASE) and label not in matched_sizes:
+                matched_sizes.append(label)
+
+        if not matched_sizes:
+            continue
+
+        for size_label in matched_sizes:
+            line: dict[str, object] = {
+                'productName': product_name,
+                'colorName': color_name,
+                'sizeLabel': size_label,
+                'quantity': quantity,
+            }
+            if unit_cost is not None:
+                line['unitCost'] = unit_cost
+            lines.append(line)
+
+    return lines
 
 
 class AgentRuntimeService:
@@ -1290,6 +1457,12 @@ class AgentRuntimeService:
                 updated_payload=updated_payload,
                 task_entities=task_entities,
             )
+        if tool_name == 'purchasing.create_po':
+            updated_payload = self._reuse_last_po_lines_from_context(
+                user_message=user_message,
+                current_entities=current_entities,
+                merged_payload=updated_payload,
+            )
         updated_payload = await self._merge_direct_follow_up_payload(
             auth=auth,
             user_message=user_message,
@@ -1374,6 +1547,12 @@ class AgentRuntimeService:
                 tool_name=tool_name,
                 updated_payload=updated_payload,
                 task_entities=task_entities,
+            )
+        if tool_name == 'purchasing.create_po':
+            updated_payload = self._reuse_last_po_lines_from_context(
+                user_message=user_message,
+                current_entities=current_entities,
+                merged_payload=updated_payload,
             )
         updated_payload = await self._merge_direct_follow_up_payload(
             auth=auth,
@@ -1585,6 +1764,196 @@ class AgentRuntimeService:
             return [f'Possible duplicate purchase order: {listed} already has the same supplier and line items.']
         return [f'Possible duplicate purchase orders: {listed} already match this supplier and line set.']
 
+    @staticmethod
+    def _reuse_last_po_lines_from_context(
+        *,
+        user_message: str,
+        current_entities: dict[str, object],
+        merged_payload: dict[str, object],
+    ) -> dict[str, object]:
+        if not _message_requests_same_details(user_message):
+            return merged_payload
+
+        task_context = task_context_from_entities(current_entities)
+        task_entities = task_context.get('entities')
+        if not isinstance(task_entities, dict):
+            return merged_payload
+
+        raw_last_lines = task_entities.get('lastPoLines')
+        last_lines = [dict(line) for line in raw_last_lines if isinstance(line, dict)] if isinstance(raw_last_lines, list) else []
+        if not last_lines:
+            return merged_payload
+
+        next_payload = dict(merged_payload)
+        next_payload['lines'] = last_lines
+        if not _has_meaningful_value(next_payload.get('supplierId')):
+            supplier_id = task_entities.get('supplierId')
+            if supplier_id is not None:
+                next_payload['supplierId'] = supplier_id
+        return next_payload
+
+    async def _product_detail_for_reference(
+        self,
+        *,
+        auth: AuthContext,
+        reference: str,
+    ) -> dict[str, object] | None:
+        normalized = reference.strip()
+        if not normalized:
+            return None
+
+        search_skus = getattr(self._backend_client, 'search_skus', None)
+        if callable(search_skus):
+            try:
+                sku_rows = await search_skus(auth.access_token or '', auth.tenant_id, q=normalized)
+            except Exception:
+                sku_rows = []
+            if isinstance(sku_rows, list):
+                for row in sku_rows:
+                    if not isinstance(row, dict):
+                        continue
+                    product_id = str(row.get('product_id') or '').strip()
+                    if product_id:
+                        try:
+                            return await self._backend_client.get_product(auth.access_token or '', auth.tenant_id, product_id)
+                        except Exception:
+                            return None
+
+        try:
+            products = await self._backend_client.search_products(auth.access_token or '', auth.tenant_id, q=normalized)
+        except Exception:
+            return None
+        if not isinstance(products, list):
+            return None
+        for product in products:
+            if not isinstance(product, dict):
+                continue
+            product_id = str(product.get('id') or '').strip()
+            if not product_id:
+                continue
+            try:
+                return await self._backend_client.get_product(auth.access_token or '', auth.tenant_id, product_id)
+            except Exception:
+                return None
+        return None
+
+    async def _merge_create_po_line_follow_up(
+        self,
+        *,
+        auth: AuthContext,
+        user_message: str,
+        merged_payload: dict[str, object],
+    ) -> dict[str, object]:
+        raw_lines = merged_payload.get('lines')
+        lines = [dict(line) for line in raw_lines if isinstance(line, dict)] if isinstance(raw_lines, list) else []
+        if len(lines) != 1:
+            return merged_payload
+
+        line = dict(lines[0])
+        reference = str(line.get('productName') or line.get('styleCode') or line.get('skuCode') or '').strip()
+        if not reference:
+            return merged_payload
+
+        detail = await self._product_detail_for_reference(auth=auth, reference=reference)
+        if not isinstance(detail, dict):
+            return merged_payload
+
+        skus = detail.get('skus')
+        sizes = detail.get('sizes')
+        if not isinstance(skus, list) or not isinstance(sizes, list):
+            return merged_payload
+
+        available_colors = [
+            str(sku.get('color_name') or '').strip()
+            for sku in skus
+            if isinstance(sku, dict) and str(sku.get('color_name') or '').strip()
+        ]
+        available_sizes = [
+            str(size.get('size_label') or '').strip()
+            for size in sizes
+            if isinstance(size, dict) and str(size.get('size_label') or '').strip()
+        ]
+
+        existing_unit_cost = None
+        raw_unit_cost = line.get('unitCost')
+        if raw_unit_cost is not None:
+            try:
+                existing_unit_cost = int(raw_unit_cost)
+            except (TypeError, ValueError):
+                existing_unit_cost = None
+
+        grouped_lines = _extract_grouped_variant_lines(
+            message=user_message,
+            product_name=reference,
+            available_colors=available_colors,
+            available_sizes=available_sizes,
+            unit_cost=existing_unit_cost,
+        )
+        if grouped_lines:
+            next_payload = dict(merged_payload)
+            next_payload['lines'] = grouped_lines
+            return next_payload
+
+        line_patch: dict[str, object] = {}
+        color_name = _extract_follow_up_color_name(user_message, available_colors)
+        if color_name:
+            line_patch['colorName'] = color_name
+
+        size_label = _extract_follow_up_size_label(user_message, available_sizes)
+        if size_label:
+            line_patch['sizeLabel'] = size_label
+
+        quantity = _extract_follow_up_quantity(user_message)
+        if quantity is not None:
+            if 'qty' in line:
+                line_patch['qty'] = quantity
+            else:
+                line_patch['quantity'] = quantity
+
+        unit_cost = _extract_follow_up_unit_value(user_message)
+        if unit_cost is not None:
+            has_qty = _has_meaningful_value(line.get('qty')) or _has_meaningful_value(line.get('quantity'))
+            has_cost = _has_meaningful_value(line.get('unitCost'))
+            if not has_cost or not quantity or not has_qty:
+                line_patch['unitCost'] = unit_cost
+
+        merged_lines = _merge_single_line_patch(lines, line_patch)
+        if merged_lines is None:
+            return merged_payload
+        next_payload = dict(merged_payload)
+        next_payload['lines'] = merged_lines
+        return next_payload
+
+    async def _variant_rows_for_clarification(
+        self,
+        *,
+        catalog: SemanticToolCatalog,
+        tool_name: str,
+        tool_arguments: dict[str, object],
+        prompt: str,
+    ) -> dict[str, object] | None:
+        lowered_prompt = prompt.lower()
+        if tool_name not in {'purchasing.create_po', 'sales.create_invoice'}:
+            return None
+
+        raw_lines = tool_arguments.get('lines')
+        lines = [line for line in raw_lines if isinstance(line, dict)] if isinstance(raw_lines, list) else []
+        if len(lines) != 1:
+            return None
+        line = lines[0]
+        if line.get('sizeId'):
+            return None
+        product_reference = str(line.get('productName') or line.get('styleCode') or line.get('skuCode') or '').strip()
+        if not product_reference:
+            return None
+        if not any(marker in lowered_prompt for marker in ('variant', 'color', 'colour', 'size', 'available', 'quantity')):
+            return None
+
+        try:
+            return await catalog.invoke('products.get_product_variants', {'product': product_reference})
+        except Exception:
+            return None
+
     async def _merge_direct_follow_up_payload(
         self,
         *,
@@ -1608,7 +1977,12 @@ class AgentRuntimeService:
             )
             if lines:
                 merged_payload['lines'] = lines
-            return merged_payload
+                return merged_payload
+            return await self._merge_create_po_line_follow_up(
+                auth=auth,
+                user_message=user_message,
+                merged_payload=merged_payload,
+            )
 
         if tool_name == 'sales.create_invoice':
             customer = await match_customer(self._backend_client, auth, user_message)
@@ -1763,6 +2137,40 @@ class AgentRuntimeService:
         current_entities: dict[str, object],
     ) -> tuple[str, dict[str, object]] | None:
         recovered: dict[str, object] = {}
+
+        if primary_intent == 'purchasing.create_po':
+            supplier = await match_supplier(self._backend_client, auth, user_message)
+            if supplier:
+                recovered['supplierId'] = supplier['id']
+            else:
+                task_context = task_context_from_entities(current_entities)
+                task_entities = task_context.get('entities')
+                if isinstance(task_entities, dict):
+                    supplier_id = str(task_entities.get('supplierId') or '').strip()
+                    if supplier_id:
+                        recovered['supplierId'] = supplier_id
+
+            lines = await parse_po_lines(
+                self._backend_client,
+                auth,
+                user_message,
+                po_id='',
+                allow_missing_cost=True,
+            )
+            if lines:
+                recovered['lines'] = lines
+            else:
+                product_reference = _extract_order_product_reference(user_message)
+                if product_reference:
+                    recovered['lines'] = [{'productName': product_reference}]
+
+            date_value = _parse_iso_date_from_message(user_message)
+            if date_value:
+                recovered['expectedDate'] = date_value
+
+            if recovered.get('supplierId') and recovered.get('lines'):
+                return primary_intent, recovered
+            return None
 
         if primary_intent == 'purchasing.update_po':
             po_ref = _extract_purchase_order_reference(user_message)
@@ -1980,8 +2388,23 @@ class AgentRuntimeService:
                 'executionPayload': tool_arguments,
             }
             next_entities = self._clarification_entities(draft_entities, required)
+            clarification_blocks = render_clarification(exc.prompt, required)
+            variant_rows = await self._variant_rows_for_clarification(
+                catalog=catalog,
+                tool_name=tool_name,
+                tool_arguments=tool_arguments,
+                prompt=exc.prompt,
+            )
+            if isinstance(variant_rows, dict):
+                clarification_blocks.extend(
+                    render_tool_result(
+                        'Available variants for this product:',
+                        'products.get_product_variants',
+                        variant_rows,
+                    )
+                )
             return RuntimeOutcome(
-                blocks=render_clarification(exc.prompt, required),
+                blocks=clarification_blocks,
                 status=WorkflowStatus.NEEDS_INPUT,
                 current_task='clarification_requested',
                 extracted_entities=next_entities,
@@ -2112,19 +2535,60 @@ class AgentRuntimeService:
         updated_payload: dict[str, object],
         task_entities: dict[str, object],
     ) -> dict[str, object]:
-        if tool_name != 'products.create_product':
-            return updated_payload
-
         merged_payload = dict(updated_payload)
-        product = dict(merged_payload.get('product') or {})
-        if task_entities.get('styleCode'):
-            product['styleCode'] = task_entities['styleCode']
-        if task_entities.get('name'):
-            product['name'] = task_entities['name']
-        if task_entities.get('basePrice') is not None:
-            product['basePrice'] = task_entities['basePrice']
-        if product:
-            merged_payload['product'] = product
+        if tool_name in {'master.create_supplier', 'master.create_customer'}:
+            for key in ('name', 'email', 'phone', 'address', 'status'):
+                value = task_entities.get(key)
+                if value is None:
+                    continue
+                if isinstance(value, str):
+                    cleaned = value.strip()
+                    if cleaned:
+                        merged_payload[key] = cleaned
+                else:
+                    merged_payload[key] = value
+            return merged_payload
+
+        if tool_name == 'products.create_product':
+            product = dict(merged_payload.get('product') or {})
+            if task_entities.get('styleCode'):
+                product['styleCode'] = task_entities['styleCode']
+            if task_entities.get('name'):
+                product['name'] = task_entities['name']
+            if task_entities.get('basePrice') is not None:
+                product['basePrice'] = task_entities['basePrice']
+            if product:
+                merged_payload['product'] = product
+            return merged_payload
+
+        if tool_name in {'purchasing.create_po', 'sales.create_invoice'}:
+            if isinstance(merged_payload.get('lines'), list) and merged_payload.get('lines'):
+                return merged_payload
+            price_field = 'unitCost' if tool_name == 'purchasing.create_po' else 'unitPrice'
+            candidate_patch: dict[str, object] = {}
+            for key in ('productName', 'styleCode', 'skuCode', 'colorName'):
+                value = task_entities.get(key)
+                if isinstance(value, str) and value.strip():
+                    candidate_patch[key] = value.strip()
+            size_label = _normalize_size_label(task_entities.get('sizeLabel'))
+            if size_label:
+                candidate_patch['sizeLabel'] = size_label
+            if task_entities.get('quantity') is not None:
+                candidate_patch['quantity'] = task_entities['quantity']
+            elif task_entities.get('qty') is not None:
+                candidate_patch['qty'] = task_entities['qty']
+            if task_entities.get(price_field) is not None:
+                candidate_patch[price_field] = task_entities[price_field]
+            elif task_entities.get('price') is not None:
+                candidate_patch[price_field] = task_entities['price']
+            elif task_entities.get('unitPrice') is not None and price_field == 'unitCost':
+                candidate_patch[price_field] = task_entities['unitPrice']
+            elif task_entities.get('unitCost') is not None and price_field == 'unitPrice':
+                candidate_patch[price_field] = task_entities['unitCost']
+
+            merged_lines = _merge_single_line_patch(merged_payload.get('lines'), candidate_patch)
+            if merged_lines is not None:
+                merged_payload['lines'] = merged_lines
         return merged_payload
 
     @staticmethod
@@ -2407,7 +2871,7 @@ class AgentRuntimeService:
         # Purchasing
         if primary_intent == 'purchasing.create_po':
             return (
-                'Reply with the supplier name and PO lines in the format `SKUCODE/SIZE xQTY @UNIT_COST`, separated by commas.',
+                'Reply with the supplier plus the product, color, size, and quantity for each PO line. Unit cost is optional if you want to use the product default.',
                 ['supplier_id', 'lines'],
             )
         if primary_intent == 'purchasing.receive_po':
@@ -2591,6 +3055,9 @@ class AgentRuntimeService:
                 entities['supplierId'] = supplier_id
             if supplier_name:
                 entities['supplierName'] = supplier_name
+            raw_lines = tool_arguments.get('lines')
+            if isinstance(raw_lines, list):
+                entities['lastPoLines'] = [dict(line) for line in raw_lines if isinstance(line, dict)]
             po_id = str(result_payload.get('id') or result_payload.get('poId') or '').strip()
             po_number = str(result_payload.get('poNumber') or result_payload.get('number') or '').strip()
             if po_id:

--- a/conversational-engine/src/conversational_engine/runtime/service.py
+++ b/conversational-engine/src/conversational_engine/runtime/service.py
@@ -13,12 +13,20 @@ from conversational_engine.agents.narrator import NarratorAgent
 from conversational_engine.agents.planner import PlannerAgent
 from conversational_engine.agents.reviewer import ReviewerAgent
 from conversational_engine.agents.state_updater import StateUpdateAgent
-from conversational_engine.clients.backend import BackendClient
+from conversational_engine.audit.service import AuditService
+from conversational_engine.clients.backend import BackendClient, BackendValidationError
 from conversational_engine.contracts.auth import AuthContext
 from conversational_engine.contracts.common import PendingActionType, TextBlock, WorkflowStatus
 from conversational_engine.memory.layered import LayeredMemoryService
 from conversational_engine.retrieval.service import RetrievalService
 from conversational_engine.runtime.contracts import RuntimeOutcome
+from conversational_engine.runtime.commerce_matching import (
+    match_customer,
+    match_location,
+    match_supplier,
+    parse_po_lines,
+    parse_sales_lines,
+)
 from conversational_engine.runtime.renderer import (
     render_clarification,
     render_confirmation_required,
@@ -37,15 +45,340 @@ from conversational_engine.runtime.state_update import (
     task_context_from_entities,
 )
 from conversational_engine.tools.catalog import SemanticToolCatalog
+from conversational_engine.tools.catalog.resolvers import EntityResolver
 from conversational_engine.tools.catalog.utils import ToolPreparationError
+from conversational_engine.tools.validation import ToolSchemaValidationError
 from conversational_engine.training.service import TrainingDataService
 
 EventSink = Callable[[str, dict[str, object]], None]
 logger = logging.getLogger(__name__)
 
+_WRITE_TOOL_ENTITY_FIELDS: dict[str, tuple[str, ...]] = {
+    'master.create_location': ('name', 'code', 'type', 'address', 'status'),
+    'purchasing.cancel_po': ('poId',),
+    'purchasing.close_po': ('poId',),
+    'purchasing.create_po': ('supplierId', 'expectedDate', 'lines'),
+    'purchasing.receive_po': ('poId', 'locationId', 'lines'),
+    'purchasing.update_po': ('poId', 'headerPatch', 'lines', 'lineOps'),
+    'sales.cancel_invoice': ('invoiceId',),
+    'sales.create_invoice': ('customerId', 'lines'),
+    'sales.dispatch_invoice': ('invoiceId', 'locationId'),
+    'sales.update_invoice': ('invoiceId', 'headerPatch', 'lines', 'lineOps'),
+}
+_WRITE_TOOL_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
+    'master.create_location': ('name', 'code', 'type'),
+    'purchasing.cancel_po': ('poId',),
+    'purchasing.close_po': ('poId',),
+    'purchasing.create_po': ('supplierId', 'lines'),
+    'purchasing.receive_po': ('poId', 'locationId', 'lines'),
+    'purchasing.update_po': ('poId',),
+    'sales.cancel_invoice': ('invoiceId',),
+    'sales.create_invoice': ('customerId', 'lines'),
+    'sales.dispatch_invoice': ('invoiceId', 'locationId'),
+    'sales.update_invoice': ('invoiceId',),
+}
+_COMPOUND_SEQUENCE_VERBS = (
+    'create',
+    'add',
+    'new',
+    'onboard',
+    'register',
+    'update',
+    'edit',
+    'change',
+    'rename',
+    'delete',
+    'remove',
+    'dispatch',
+    'ship',
+    'cancel',
+    'receive',
+    'book in',
+    'close',
+    'show',
+    'find',
+    'search',
+    'list',
+)
+_COMPOUND_SEQUENCE_SPLIT_PATTERN = re.compile(
+    r'\s*(?:,\s*)?(?:then|and then)\s+|\s*,?\s+and\s+(?=(?:'
+    + '|'.join(re.escape(verb) for verb in _COMPOUND_SEQUENCE_VERBS)
+    + r')\b)',
+    re.IGNORECASE,
+)
+_COMPOUND_SEQUENCE_ACTION_PATTERN = re.compile(
+    r'^(?:' + '|'.join(re.escape(verb) for verb in _COMPOUND_SEQUENCE_VERBS) + r')\b',
+    re.IGNORECASE,
+)
+
 
 def _estimate_tokens(text: str) -> int:
     return max(1, (len(text.strip()) + 3) // 4)
+
+
+def _has_meaningful_value(value: object) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, dict, tuple, set)):
+        return bool(value)
+    return True
+
+
+def _is_generic_clarification_prompt(prompt: str) -> bool:
+    normalized = ' '.join(prompt.strip().split()).lower()
+    return normalized in {
+        '',
+        'please clarify your request.',
+        'please clarify your request',
+        'could you clarify what you need?',
+        'could you clarify your request?',
+    }
+
+
+def _parse_iso_date_from_message(message: str) -> str | None:
+    match = re.search(r'\b(20\d{2}-\d{2}-\d{2})\b', message)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def _extract_quantity_change_ops(message: str) -> list[dict[str, object]]:
+    ops: list[dict[str, object]] = []
+    patterns = (
+        re.compile(
+            r'(?:change|update|adjust|set)\s+(?:the\s+)?quantity(?:\s+of)?\s+'
+            r'(?P<sku>[A-Za-z0-9-]+)\s*/\s*(?P<size>[A-Za-z0-9]+)\s+(?:to|=)\s*(?P<qty>\d+)',
+            re.IGNORECASE,
+        ),
+        re.compile(
+            r'(?P<sku>[A-Za-z0-9-]+)\s*/\s*(?P<size>[A-Za-z0-9]+)\s+'
+            r'(?:quantity\s+)?(?:to|=)\s*(?P<qty>\d+)',
+            re.IGNORECASE,
+        ),
+    )
+    for pattern in patterns:
+        for match in pattern.finditer(message):
+            ops.append(
+                {
+                    'op': 'change_qty',
+                    'lineRef': {
+                        'skuCode': match.group('sku').upper(),
+                        'sizeLabel': match.group('size').upper(),
+                    },
+                    'qty': int(match.group('qty')),
+                }
+            )
+        if ops:
+            break
+    return ops
+
+
+def _extract_remove_line_ops(message: str) -> list[dict[str, object]]:
+    ops: list[dict[str, object]] = []
+    pattern = re.compile(
+        r'(?:remove|removing|delete|deleting|drop|dropping)\s+(?:the\s+)?(?:line\s+)?'
+        r'(?P<sku>[A-Za-z0-9-]+)\s*/\s*(?P<size>[A-Za-z0-9]+)\b',
+        re.IGNORECASE,
+    )
+    for match in pattern.finditer(message):
+        ops.append(
+            {
+                'op': 'remove',
+                'lineRef': {
+                    'skuCode': match.group('sku').upper(),
+                    'sizeLabel': match.group('size').upper(),
+                },
+            }
+        )
+    return ops
+
+
+def _message_implies_add_line(message: str) -> bool:
+    return bool(re.search(r'\badd(?:\s+another)?\s+line\b|\badd\b', message, re.IGNORECASE))
+
+
+def _merge_line_ops(
+    existing_ops: object,
+    new_ops: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    merged_ops = [op for op in existing_ops if isinstance(op, dict)] if isinstance(existing_ops, list) else []
+    for new_op in new_ops:
+        new_name = str(new_op.get('op') or '')
+        new_ref = new_op.get('lineRef')
+        if new_name and isinstance(new_ref, dict):
+            merged_ops = [
+                existing_op
+                for existing_op in merged_ops
+                if not (
+                    str(existing_op.get('op') or '') == new_name
+                    and existing_op.get('lineRef') == new_ref
+                )
+            ]
+        merged_ops.append(new_op)
+    return merged_ops
+
+
+def _extract_purchase_order_reference(message: str) -> str | None:
+    patterns = (
+        re.compile(
+            r'\b(?:my\s+last|last|latest)\s+(?:purchase order|po)\s+for\s+[^,.;]+?(?=\s+(?:expected|status|with|from|to|at|change|update|cancel|close|receive|dispatch)\b|$)',
+            re.IGNORECASE,
+        ),
+        re.compile(r'\b(?:my\s+last|last|latest)\s+(?:purchase order|po)\b', re.IGNORECASE),
+        re.compile(r'\b(?:this|that)\s+(?:purchase order|po)\b', re.IGNORECASE),
+        re.compile(r'\bpo[-\s]?\d+\b', re.IGNORECASE),
+        re.compile(
+            r'\b(?:purchase order|po)\s+for\s+([^,.;]+?)(?=\s+(?:expected|status|with|from|to|at|by|change|changing|update|updating|cancel|close|receive)\b|$)',
+            re.IGNORECASE,
+        ),
+    )
+    for pattern in patterns:
+        match = pattern.search(message)
+        if not match:
+            continue
+        if match.lastindex:
+            return str(match.group(1)).strip()
+        return match.group(0).strip()
+    return None
+
+
+def _extract_invoice_reference(message: str) -> str | None:
+    patterns = (
+        re.compile(
+            r'\b(?:my\s+last|last|latest)\s+(?:sales order|invoice|so)\s+for\s+[^,.;]+?(?=\s+(?:from|to|at|status|with|by|change|changing|update|updating|cancel|dispatch|receive)\b|$)',
+            re.IGNORECASE,
+        ),
+        re.compile(r'\b(?:my\s+last|last|latest)\s+(?:sales order|invoice|so)\b', re.IGNORECASE),
+        re.compile(r'\b(?:this|that)\s+(?:sales order|invoice|so)\b', re.IGNORECASE),
+        re.compile(r'\bso[-\s]?\d+\b', re.IGNORECASE),
+        re.compile(
+            r'\b(?:sales order|invoice|so)\s+for\s+([^,.;]+?)(?=\s+(?:from|to|at|status|with|by|change|changing|update|updating|cancel|dispatch)\b|$)',
+            re.IGNORECASE,
+        ),
+    )
+    for pattern in patterns:
+        match = pattern.search(message)
+        if not match:
+            continue
+        if match.lastindex:
+            return str(match.group(1)).strip()
+        return match.group(0).strip()
+    return None
+
+
+_ORDINAL_LINE_INDEX: dict[str, int] = {
+    '1st': 0,
+    'first': 0,
+    '2nd': 1,
+    'second': 1,
+    '3rd': 2,
+    'third': 2,
+    '4th': 3,
+    'fourth': 3,
+    '5th': 4,
+    'fifth': 4,
+    'last': -1,
+}
+
+_SIZE_LABEL_ALIASES: tuple[tuple[str, str], ...] = (
+    ('extra extra small', 'XXS'),
+    ('xxs', 'XXS'),
+    ('extra small', 'XS'),
+    ('xs', 'XS'),
+    ('small', 'S'),
+    ('sm', 'S'),
+    ('medium', 'M'),
+    ('med', 'M'),
+    ('md', 'M'),
+    ('large', 'L'),
+    ('lg', 'L'),
+    ('extra large', 'XL'),
+    ('xl', 'XL'),
+    ('extra extra large', 'XXL'),
+    ('xxl', 'XXL'),
+)
+
+
+def _extract_ordinal_line_quantity_change(message: str) -> tuple[int, int] | None:
+    patterns = (
+        re.compile(
+            r'(?:change|changing|update|updating|adjust|adjusting|set|setting)\s+(?:the\s+)?(?P<ordinal>1st|first|2nd|second|3rd|third|4th|fourth|5th|fifth|last)\s+line(?:\s+quantity)?\s+(?:to|=)\s*(?P<qty>\d+)',
+            re.IGNORECASE,
+        ),
+        re.compile(
+            r'(?:change|changing|update|updating|adjust|adjusting|set|setting)\s+quantity(?:\s+of)?\s+(?:the\s+)?(?P<ordinal>1st|first|2nd|second|3rd|third|4th|fourth|5th|fifth|last)\s+line\s+(?:to|=)\s*(?P<qty>\d+)',
+            re.IGNORECASE,
+        ),
+    )
+    for pattern in patterns:
+        match = pattern.search(message)
+        if not match:
+            continue
+        ordinal = match.group('ordinal').lower()
+        return _ORDINAL_LINE_INDEX[ordinal], int(match.group('qty'))
+    return None
+
+
+def _extract_ordinal_line_remove(message: str) -> int | None:
+    match = re.search(
+        r'(?:remove|removing|delete|deleting|drop|dropping)\s+(?:the\s+)?(?P<ordinal>1st|first|2nd|second|3rd|third|4th|fourth|5th|fifth|last)\s+line\b',
+        message,
+        re.IGNORECASE,
+    )
+    if not match:
+        return None
+    return _ORDINAL_LINE_INDEX[match.group('ordinal').lower()]
+
+
+def _extract_line_size_label_reference(message: str) -> str | None:
+    lowered = message.lower()
+    if 'line' not in lowered:
+        return None
+    for alias, label in _SIZE_LABEL_ALIASES:
+        if re.search(rf'\b{re.escape(alias)}\b', lowered, re.IGNORECASE):
+            return label
+    return None
+
+
+def _extract_line_quantity_value(message: str) -> int | None:
+    patterns = (
+        re.compile(
+            r'(?:change|changing|update|updating|adjust|adjusting|set|setting)\s+(?:the\s+)?(?:[a-z]+\s+)*line(?:\s+quantity)?\s+(?:to|=)\s*(?P<qty>\d+)',
+            re.IGNORECASE,
+        ),
+        re.compile(
+            r'(?:change|changing|update|updating|adjust|adjusting|set|setting)\s+quantity(?:\s+of)?\s+(?:the\s+)?(?:[a-z]+\s+)*line\s+(?:to|=)\s*(?P<qty>\d+)',
+            re.IGNORECASE,
+        ),
+    )
+    for pattern in patterns:
+        match = pattern.search(message)
+        if match:
+            return int(match.group('qty'))
+    return None
+
+
+def _message_implies_remove_line(message: str) -> bool:
+    return bool(
+        re.search(r'\b(?:remove|removing|delete|deleting|drop|dropping)\b', message, re.IGNORECASE)
+        and 'line' in message.lower()
+    )
+
+
+def _canonical_po_line_signature(line: dict[str, object]) -> tuple[str, int, int] | None:
+    size_id = str(line.get('sizeId') or line.get('skuId') or '').strip()
+    if not size_id:
+        return None
+    raw_qty = line.get('qty', line.get('qtyOrdered'))
+    raw_cost = line.get('unitCost')
+    if raw_qty is None or raw_cost is None:
+        return None
+    try:
+        return (size_id, int(raw_qty), int(raw_cost))
+    except (TypeError, ValueError):
+        return None
 
 
 class AgentRuntimeService:
@@ -58,6 +391,7 @@ class AgentRuntimeService:
         reviewer: ReviewerAgent,
         narrator: NarratorAgent,
         state_updater: StateUpdateAgent | None = None,
+        audit_service: AuditService | None = None,
         memory_service: LayeredMemoryService,
         training_data_service: TrainingDataService,
         retrieval_service: RetrievalService,
@@ -68,6 +402,7 @@ class AgentRuntimeService:
         self._reviewer = reviewer
         self._state_updater = state_updater
         self._narrator = narrator
+        self._audit_service = audit_service
         self._memory_service = memory_service
         self._training_data_service = training_data_service
         self._retrieval_service = retrieval_service
@@ -86,8 +421,19 @@ class AgentRuntimeService:
         run_id: UUID,
         image_data_urls: tuple[str, ...] = (),
     ) -> RuntimeOutcome:
+        queued_message, queued_entities = self._start_compound_sequence(
+            user_message=user_message,
+            extracted_entities=extracted_entities,
+            workflow_status=workflow_status,
+        )
+        user_message = queued_message
+        extracted_entities = queued_entities
         tool_history: list[dict[str, object]] = []
-        catalog = SemanticToolCatalog(backend=self._backend_client, auth=auth)
+        catalog = SemanticToolCatalog(
+            backend=self._backend_client,
+            auth=auth,
+            context_entities=extracted_entities,
+        )
         usage_entries: list[dict[str, object]] = []
         trace_tasks: list[asyncio.Task[None]] = []
 
@@ -136,6 +482,17 @@ class AgentRuntimeService:
                     extracted_entities=mark_task_status(current_entities, 'completed'),
                 )
 
+            if state_update.primary_intent == 'off_topic':
+                message = (
+                    'I can help with inventory, products, purchasing, sales orders, suppliers, customers, and reports.'
+                )
+                return RuntimeOutcome(
+                    blocks=render_tool_result(message, 'assistant.response', {}),
+                    status=WorkflowStatus.COMPLETED,
+                    current_task='off_topic_redirected',
+                    extracted_entities=mark_task_status(current_entities, 'completed'),
+                )
+
             for post_action in state_update.new_post_actions:
                 route = post_action.get('route')
                 emit(
@@ -155,6 +512,7 @@ class AgentRuntimeService:
 
             direct_confirmation_outcome = await self._handle_confirmation_edit(
                 auth=auth,
+                user_message=user_message,
                 workflow_status=workflow_status,
                 workflow_id=workflow_id,
                 conversation_id=conversation_id,
@@ -166,6 +524,7 @@ class AgentRuntimeService:
                 return direct_confirmation_outcome
             direct_clarification_outcome = await self._handle_clarification_reply(
                 auth=auth,
+                user_message=user_message,
                 workflow_status=workflow_status,
                 workflow_id=workflow_id,
                 conversation_id=conversation_id,
@@ -299,6 +658,11 @@ class AgentRuntimeService:
                 )
 
                 if plan.get('action') == 'clarify':
+                    question_prompt, required = self._clarification_prompt_and_required(
+                        primary_intent=state_update.primary_intent,
+                        suggested_prompt=plan.get('clarificationQuestion'),
+                        suggested_required=plan.get('requiredInputs'),
+                    )
                     question = await self._run_phase(
                         emit=emit,
                         conversation_id=conversation_id,
@@ -308,15 +672,14 @@ class AgentRuntimeService:
                         intent=state_update.primary_intent,
                         action=lambda: self._narrator.write_message(
                             user_message=state_update.planner_message,
-                            directive=str(plan.get('clarificationQuestion') or 'Please clarify your request.'),
+                            directive=question_prompt,
                             supporting_context={
-                                'requiredInputs': plan.get('requiredInputs') or [],
+                                'requiredInputs': required,
                                 'goal': plan.get('goal'),
                             },
                             trace_callback=record_trace('narrator', iteration),
                         ),
                     )
-                    required = [str(item) for item in plan.get('requiredInputs') or []]
                     emit('assistant.message.delta', {'content': question})
                     emit(
                         'clarification.requested',
@@ -329,10 +692,7 @@ class AgentRuntimeService:
                             status='needs_input',
                         ),
                     )
-                    next_entities = mark_task_status(
-                        apply_task_context(current_entities, increment_clarification_count(task_context_from_entities(current_entities))),
-                        'drafting',
-                    )
+                    next_entities = self._clarification_entities(current_entities, required)
                     return RuntimeOutcome(
                         blocks=render_clarification(question, required),
                         status=WorkflowStatus.NEEDS_INPUT,
@@ -376,6 +736,7 @@ class AgentRuntimeService:
                         plan=plan,
                         tools=self._schema_catalog_for_state(catalog, state_update),
                         history=tool_history,
+                        expected_tool_name=state_update.primary_intent or None,
                         trace_callback=record_trace('executor', iteration),
                     ),
                 )
@@ -396,6 +757,11 @@ class AgentRuntimeService:
                 )
 
                 if proposal.get('action') == 'clarify':
+                    question_prompt, required = self._clarification_prompt_and_required(
+                        primary_intent=state_update.primary_intent,
+                        suggested_prompt=proposal.get('assistantMessage'),
+                        suggested_required=proposal.get('requiredInputs'),
+                    )
                     question = await self._run_phase(
                         emit=emit,
                         conversation_id=conversation_id,
@@ -405,15 +771,14 @@ class AgentRuntimeService:
                         intent=state_update.primary_intent,
                         action=lambda: self._narrator.write_message(
                             user_message=state_update.planner_message,
-                            directive=str(proposal.get('assistantMessage') or 'Please clarify your request.'),
+                            directive=question_prompt,
                             supporting_context={
-                                'requiredInputs': proposal.get('requiredInputs') or [],
+                                'requiredInputs': required,
                                 'plan': plan,
                             },
                             trace_callback=record_trace('narrator', iteration),
                         ),
                     )
-                    required = [str(item) for item in proposal.get('requiredInputs') or []]
                     emit('assistant.message.delta', {'content': question})
                     emit(
                         'clarification.requested',
@@ -426,10 +791,7 @@ class AgentRuntimeService:
                             status='needs_input',
                         ),
                     )
-                    next_entities = mark_task_status(
-                        apply_task_context(current_entities, increment_clarification_count(task_context_from_entities(current_entities))),
-                        'drafting',
-                    )
+                    next_entities = self._clarification_entities(current_entities, required)
                     return RuntimeOutcome(
                         blocks=render_clarification(question, required),
                         status=WorkflowStatus.NEEDS_INPUT,
@@ -469,20 +831,42 @@ class AgentRuntimeService:
                         tool_arguments=tool_arguments,
                         current_entities=current_entities,
                     )
-                if not tool_name or not isinstance(tool_arguments, dict):
+                if (
+                    not tool_name
+                    or not isinstance(tool_arguments, dict)
+                    or self._tool_arguments_need_clarification(tool_name=tool_name, tool_arguments=tool_arguments)
+                ):
+                    recovered = await self._recover_sparse_mutation_payload(
+                        auth=auth,
+                        user_message=user_message,
+                        primary_intent=state_update.primary_intent,
+                        current_entities=current_entities,
+                    )
+                    if recovered is not None:
+                        tool_name, tool_arguments = recovered
+                    else:
+                        logger.error('Invalid executor proposal: %s', proposal)
+                        prompt, required = self._fallback_clarification_for_intent(state_update.primary_intent)
+                        return RuntimeOutcome(
+                            blocks=render_clarification(prompt, required),
+                            status=WorkflowStatus.NEEDS_INPUT,
+                            current_task='tool_call_invalid',
+                            extracted_entities=self._clarification_entities(current_entities, required),
+                            missing_fields=required,
+                        )
+
+                if (
+                    not tool_name
+                    or not isinstance(tool_arguments, dict)
+                    or self._tool_arguments_need_clarification(tool_name=tool_name, tool_arguments=tool_arguments)
+                ):
                     logger.error('Invalid executor proposal: %s', proposal)
                     prompt, required = self._fallback_clarification_for_intent(state_update.primary_intent)
                     return RuntimeOutcome(
                         blocks=render_clarification(prompt, required),
                         status=WorkflowStatus.NEEDS_INPUT,
                         current_task='tool_call_invalid',
-                        extracted_entities=mark_task_status(
-                            apply_task_context(
-                                current_entities,
-                                increment_clarification_count(task_context_from_entities(current_entities)),
-                            ),
-                            'drafting',
-                        ),
+                        extracted_entities=self._clarification_entities(current_entities, required),
                         missing_fields=required,
                     )
 
@@ -525,6 +909,15 @@ class AgentRuntimeService:
                     )
 
                 try:
+                    catalog.validate(tool_name, tool_arguments)
+                except ToolSchemaValidationError as exc:
+                    return self._clarification_outcome_from_schema_error(
+                        current_entities=current_entities,
+                        required=exc.required_fields,
+                        prompt=exc.prompt,
+                    )
+
+                try:
                     tool_result = await self._run_phase(
                         emit=emit,
                         conversation_id=conversation_id,
@@ -534,6 +927,37 @@ class AgentRuntimeService:
                         intent=state_update.primary_intent,
                         tool_name=tool_name,
                         action=lambda: catalog.invoke(tool_name, tool_arguments),
+                    )
+                except BackendValidationError as exc:
+                    last_error = exc.user_message
+                    emit(
+                        'tool.error',
+                        self._event_payload(
+                            conversation_id=conversation_id,
+                            workflow_id=workflow_id,
+                            phase='execution',
+                            route=state_update.primary_route,
+                            intent=state_update.primary_intent,
+                            tool_name=tool_name,
+                            status='failed',
+                            extra={'error': last_error},
+                        ),
+                    )
+                    tool_history.append(
+                        {
+                            'plan': plan,
+                            'proposal': proposal,
+                            'toolError': last_error,
+                            'errorType': 'backend_validation',
+                        }
+                    )
+                    if iteration < 2:
+                        continue
+                    return RuntimeOutcome(
+                        blocks=render_failure(last_error),
+                        status=WorkflowStatus.FAILED,
+                        current_task='tool_validation_failed',
+                        extracted_entities=current_entities,
                     )
                 except Exception as exc:
                     emit(
@@ -563,6 +987,19 @@ class AgentRuntimeService:
                         status='completed',
                     ),
                 )
+                await self._record_audit_event(
+                    auth=auth,
+                    conversation_id=conversation_id,
+                    workflow_id=workflow_id,
+                    event_type='tool_executed',
+                    tool_name=tool_name,
+                    payload={
+                        'route': state_update.primary_route,
+                        'intent': state_update.primary_intent,
+                        'toolArguments': tool_arguments,
+                        'toolResult': tool_result,
+                    },
+                )
 
                 review = await self._run_phase(
                     emit=emit,
@@ -585,6 +1022,11 @@ class AgentRuntimeService:
                 tool_history.append({'plan': plan, 'proposal': proposal, 'toolResult': tool_result, 'review': review})
 
                 if review.get('action') == 'clarify':
+                    question_prompt, required = self._clarification_prompt_and_required(
+                        primary_intent=state_update.primary_intent,
+                        suggested_prompt=review.get('assistantMessage'),
+                        suggested_required=review.get('requiredInputs'),
+                    )
                     question = await self._run_phase(
                         emit=emit,
                         conversation_id=conversation_id,
@@ -594,12 +1036,11 @@ class AgentRuntimeService:
                         intent=state_update.primary_intent,
                         action=lambda: self._narrator.write_message(
                             user_message=state_update.planner_message,
-                            directive=str(review.get('assistantMessage') or 'Please clarify your request.'),
-                            supporting_context={'requiredInputs': review.get('requiredInputs') or []},
+                            directive=question_prompt,
+                            supporting_context={'requiredInputs': required},
                             trace_callback=record_trace('narrator', iteration),
                         ),
                     )
-                    required = [str(item) for item in review.get('requiredInputs') or []]
                     emit('assistant.message.delta', {'content': question})
                     emit(
                         'clarification.requested',
@@ -612,10 +1053,7 @@ class AgentRuntimeService:
                             status='needs_input',
                         ),
                     )
-                    next_entities = mark_task_status(
-                        apply_task_context(current_entities, increment_clarification_count(task_context_from_entities(current_entities))),
-                        'drafting',
-                    )
+                    next_entities = self._clarification_entities(current_entities, required)
                     return RuntimeOutcome(
                         blocks=render_clarification(question, required),
                         status=WorkflowStatus.NEEDS_INPUT,
@@ -625,6 +1063,20 @@ class AgentRuntimeService:
                     )
 
                 if review.get('action') == 'complete':
+                    if self._tool_result_has_no_matches(tool_result):
+                        return RuntimeOutcome(
+                            blocks=render_tool_result("I couldn't find any matches.", tool_name, tool_result),
+                            status=WorkflowStatus.COMPLETED,
+                            current_task='completed',
+                            extracted_entities=mark_task_status(
+                                {
+                                    **current_entities,
+                                    'lastToolName': tool_name,
+                                },
+                                'completed',
+                                clear_post_actions=True,
+                            ),
+                        )
                     message = await self._run_phase(
                         emit=emit,
                         conversation_id=conversation_id,
@@ -784,6 +1236,7 @@ class AgentRuntimeService:
         self,
         *,
         auth: AuthContext,
+        user_message: str,
         workflow_status: WorkflowStatus | None,
         workflow_id: UUID,
         conversation_id: UUID,
@@ -791,7 +1244,7 @@ class AgentRuntimeService:
         state_update: RuntimeStateUpdate,
         emit: EventSink,
     ) -> RuntimeOutcome | None:
-        if workflow_status != WorkflowStatus.AWAITING_CONFIRMATION:
+        if workflow_status not in {WorkflowStatus.AWAITING_CONFIRMATION, WorkflowStatus.AWAITING_APPROVAL}:
             return None
         tool_name = str(current_entities.get('toolName') or '')
         execution_payload = current_entities.get('executionPayload')
@@ -832,6 +1285,17 @@ class AgentRuntimeService:
                     'reason',
                 } and value is not None:
                     updated_payload[key] = value
+            updated_payload = self._merge_follow_up_entities_into_payload(
+                tool_name=tool_name,
+                updated_payload=updated_payload,
+                task_entities=task_entities,
+            )
+        updated_payload = await self._merge_direct_follow_up_payload(
+            auth=auth,
+            user_message=user_message,
+            tool_name=tool_name,
+            updated_payload=updated_payload,
+        )
 
         planner_text = state_update.planner_message.lower()
         if tool_name == 'inventory.receive_stock':
@@ -862,7 +1326,11 @@ class AgentRuntimeService:
         )
         return await self._prepare_confirmation(
             auth=auth,
-            catalog=SemanticToolCatalog(backend=self._backend_client, auth=auth),
+            catalog=SemanticToolCatalog(
+                backend=self._backend_client,
+                auth=auth,
+                context_entities=current_entities,
+            ),
             conversation_id=conversation_id,
             workflow_id=workflow_id,
             state_update=state_update,
@@ -877,6 +1345,7 @@ class AgentRuntimeService:
         self,
         *,
         auth: AuthContext,
+        user_message: str,
         workflow_status: WorkflowStatus | None,
         workflow_id: UUID,
         conversation_id: UUID,
@@ -896,9 +1365,22 @@ class AgentRuntimeService:
         updated_payload = dict(execution_payload)
         task_entities = state_update.task_context.get('entities')
         if isinstance(task_entities, dict):
-            for key, value in task_entities.items():
-                if value is not None:
-                    updated_payload[key] = value
+            updated_payload = self._merge_clarification_task_entities_into_payload(
+                tool_name=tool_name,
+                updated_payload=updated_payload,
+                task_entities=task_entities,
+            )
+            updated_payload = self._merge_follow_up_entities_into_payload(
+                tool_name=tool_name,
+                updated_payload=updated_payload,
+                task_entities=task_entities,
+            )
+        updated_payload = await self._merge_direct_follow_up_payload(
+            auth=auth,
+            user_message=user_message,
+            tool_name=tool_name,
+            updated_payload=updated_payload,
+        )
 
         summary_suffix = ''
         if state_update.new_post_actions:
@@ -918,7 +1400,11 @@ class AgentRuntimeService:
         )
         return await self._prepare_confirmation(
             auth=auth,
-            catalog=SemanticToolCatalog(backend=self._backend_client, auth=auth),
+            catalog=SemanticToolCatalog(
+                backend=self._backend_client,
+                auth=auth,
+                context_entities=current_entities,
+            ),
             conversation_id=conversation_id,
             workflow_id=workflow_id,
             state_update=state_update,
@@ -928,6 +1414,517 @@ class AgentRuntimeService:
             message_hint=f'Updated the draft with your latest details.{summary_suffix}'.strip(),
             emit=emit,
         )
+
+    @staticmethod
+    def _line_ref_from_detail_line(line: object) -> dict[str, object] | None:
+        if not isinstance(line, dict):
+            return None
+        line_id = str(line.get('id') or '').strip()
+        if line_id:
+            return {'lineId': line_id}
+        size_id = str(line.get('skuId') or '').strip()
+        if size_id:
+            return {'sizeId': size_id}
+        return None
+
+    async def _resolve_existing_order_line_ref(
+        self,
+        *,
+        auth: AuthContext,
+        tool_name: str,
+        updated_payload: dict[str, object],
+        user_message: str,
+    ) -> dict[str, object] | None:
+        ordinal_quantity_change = _extract_ordinal_line_quantity_change(user_message)
+        ordinal_remove = _extract_ordinal_line_remove(user_message)
+        descriptive_size_label = _extract_line_size_label_reference(user_message)
+        if ordinal_quantity_change is None and ordinal_remove is None and descriptive_size_label is None:
+            return None
+
+        detail: object = None
+        if tool_name == 'purchasing.update_po':
+            po_id = str(updated_payload.get('poId') or '').strip()
+            if not po_id:
+                return None
+            detail = await self._backend_client.get_po(auth.access_token or '', auth.tenant_id, po_id)
+        elif tool_name == 'sales.update_invoice':
+            invoice_id = str(updated_payload.get('invoiceId') or '').strip()
+            if not invoice_id:
+                return None
+            get_invoice = getattr(self._backend_client, 'get_invoice', None)
+            if not callable(get_invoice):
+                return None
+            detail = await get_invoice(auth.access_token or '', auth.tenant_id, invoice_id)
+        else:
+            return None
+
+        detail_lines = detail.get('lines') if isinstance(detail, dict) else None
+        lines = [line for line in detail_lines if isinstance(line, dict)] if isinstance(detail_lines, list) else []
+        if not lines:
+            return None
+
+        line_index: int | None = None
+        if ordinal_remove is not None:
+            line_index = ordinal_remove
+        elif ordinal_quantity_change is not None:
+            line_index = ordinal_quantity_change[0]
+        if line_index is not None:
+            if line_index < 0:
+                line_index = len(lines) - 1
+            if 0 <= line_index < len(lines):
+                return self._line_ref_from_detail_line(lines[line_index])
+
+        if descriptive_size_label is None:
+            return None
+
+        try:
+            products = await self._backend_client.search_products(auth.access_token or '', auth.tenant_id, q=None)
+        except Exception:
+            return None
+        product_rows = [row for row in products if isinstance(row, dict)] if isinstance(products, list) else []
+        if not product_rows:
+            return None
+
+        size_labels_by_size_id: dict[str, str] = {}
+        for product in product_rows:
+            product_id = str(product.get('id') or '').strip()
+            if not product_id:
+                continue
+            try:
+                product_detail = await self._backend_client.get_product(auth.access_token or '', auth.tenant_id, product_id)
+            except Exception:
+                continue
+            sizes = product_detail.get('sizes') if isinstance(product_detail, dict) else None
+            if not isinstance(sizes, list):
+                continue
+            for size in sizes:
+                if not isinstance(size, dict):
+                    continue
+                size_id = str(size.get('id') or '').strip()
+                size_label = str(size.get('size_label') or '').strip().upper()
+                if size_id and size_label:
+                    size_labels_by_size_id[size_id] = size_label
+
+        matching_refs: list[dict[str, object]] = []
+        for line in lines:
+            size_id = str(line.get('skuId') or '').strip()
+            if size_labels_by_size_id.get(size_id) != descriptive_size_label:
+                continue
+            line_ref = self._line_ref_from_detail_line(line)
+            if line_ref is not None:
+                matching_refs.append(line_ref)
+        if len(matching_refs) == 1:
+            return matching_refs[0]
+        return None
+
+    async def _build_confirmation_warnings(
+        self,
+        *,
+        auth: AuthContext,
+        tool_name: str,
+        prepared_arguments: dict[str, object],
+    ) -> list[str]:
+        if tool_name != 'purchasing.create_po':
+            return []
+
+        supplier_id = str(prepared_arguments.get('supplierId') or '').strip()
+        raw_lines = prepared_arguments.get('lines')
+        if not supplier_id or not isinstance(raw_lines, list) or not raw_lines:
+            return []
+
+        expected_signature = sorted(
+            signature
+            for signature in (
+                _canonical_po_line_signature(line)
+                for line in raw_lines
+                if isinstance(line, dict)
+            )
+            if signature is not None
+        )
+        if not expected_signature:
+            return []
+
+        try:
+            payload = await self._backend_client.list_pos(auth.access_token or '', auth.tenant_id)
+        except Exception:
+            return []
+        items = payload.get('items') if isinstance(payload, dict) else None
+        rows = [row for row in items if isinstance(row, dict)] if isinstance(items, list) else []
+
+        duplicates: list[str] = []
+        for row in rows:
+            row_supplier_id = str(row.get('supplierId') or '').strip()
+            if row_supplier_id and row_supplier_id != supplier_id:
+                continue
+            po_id = str(row.get('id') or '').strip()
+            if not po_id:
+                continue
+            try:
+                detail = await self._backend_client.get_po(auth.access_token or '', auth.tenant_id, po_id)
+            except Exception:
+                continue
+            detail_lines = detail.get('lines') if isinstance(detail, dict) else None
+            existing_signature = sorted(
+                signature
+                for signature in (
+                    _canonical_po_line_signature(line)
+                    for line in detail_lines
+                    if isinstance(detail_lines, list) and isinstance(line, dict)
+                )
+                if signature is not None
+            )
+            if existing_signature != expected_signature:
+                continue
+            po_number = str(row.get('number') or row.get('poNumber') or po_id).strip()
+            duplicates.append(po_number)
+
+        if not duplicates:
+            return []
+        listed = ', '.join(duplicates[:3])
+        if len(duplicates) == 1:
+            return [f'Possible duplicate purchase order: {listed} already has the same supplier and line items.']
+        return [f'Possible duplicate purchase orders: {listed} already match this supplier and line set.']
+
+    async def _merge_direct_follow_up_payload(
+        self,
+        *,
+        auth: AuthContext,
+        user_message: str,
+        tool_name: str,
+        updated_payload: dict[str, object],
+    ) -> dict[str, object]:
+        merged_payload = dict(updated_payload)
+
+        if tool_name == 'purchasing.create_po':
+            supplier = await match_supplier(self._backend_client, auth, user_message)
+            if supplier:
+                merged_payload['supplierId'] = supplier['id']
+            lines = await parse_po_lines(
+                self._backend_client,
+                auth,
+                user_message,
+                po_id='',
+                allow_missing_cost=True,
+            )
+            if lines:
+                merged_payload['lines'] = lines
+            return merged_payload
+
+        if tool_name == 'sales.create_invoice':
+            customer = await match_customer(self._backend_client, auth, user_message)
+            if customer:
+                merged_payload['customerId'] = customer['id']
+            lines = await parse_sales_lines(
+                self._backend_client,
+                auth,
+                user_message,
+                invoice_id='',
+            )
+            if lines:
+                merged_payload['lines'] = lines
+            return merged_payload
+
+        if tool_name == 'purchasing.update_po':
+            date_value = _parse_iso_date_from_message(user_message)
+            if date_value:
+                header_patch = dict(merged_payload.get('headerPatch') or {})
+                header_patch['expectedDate'] = date_value
+                merged_payload['headerPatch'] = header_patch
+            if _message_implies_add_line(user_message):
+                lines = await parse_po_lines(
+                    self._backend_client,
+                    auth,
+                    user_message,
+                    po_id='',
+                    allow_missing_cost=True,
+                )
+                if lines:
+                    merged_payload['lineOps'] = _merge_line_ops(
+                        merged_payload.get('lineOps'),
+                        [{'op': 'add', 'values': line} for line in lines],
+                    )
+            quantity_ops = _extract_quantity_change_ops(user_message)
+            if quantity_ops:
+                merged_payload['lineOps'] = _merge_line_ops(merged_payload.get('lineOps'), quantity_ops)
+            remove_ops = _extract_remove_line_ops(user_message)
+            if remove_ops:
+                merged_payload['lineOps'] = _merge_line_ops(merged_payload.get('lineOps'), remove_ops)
+            ordinal_line_ref = await self._resolve_existing_order_line_ref(
+                auth=auth,
+                tool_name=tool_name,
+                updated_payload=merged_payload,
+                user_message=user_message,
+            )
+            ordinal_quantity_change = _extract_ordinal_line_quantity_change(user_message)
+            if ordinal_line_ref and ordinal_quantity_change is not None:
+                merged_payload['lineOps'] = _merge_line_ops(
+                    merged_payload.get('lineOps'),
+                    [{'op': 'change_qty', 'lineRef': ordinal_line_ref, 'qty': ordinal_quantity_change[1]}],
+                )
+            descriptive_quantity = _extract_line_quantity_value(user_message)
+            if ordinal_line_ref and ordinal_quantity_change is None and descriptive_quantity is not None:
+                merged_payload['lineOps'] = _merge_line_ops(
+                    merged_payload.get('lineOps'),
+                    [{'op': 'change_qty', 'lineRef': ordinal_line_ref, 'qty': descriptive_quantity}],
+                )
+            ordinal_remove = _extract_ordinal_line_remove(user_message)
+            if ordinal_line_ref and ordinal_remove is not None:
+                merged_payload['lineOps'] = _merge_line_ops(
+                    merged_payload.get('lineOps'),
+                    [{'op': 'remove', 'lineRef': ordinal_line_ref}],
+                )
+            if ordinal_line_ref and ordinal_remove is None and not remove_ops and _message_implies_remove_line(user_message):
+                merged_payload['lineOps'] = _merge_line_ops(
+                    merged_payload.get('lineOps'),
+                    [{'op': 'remove', 'lineRef': ordinal_line_ref}],
+                )
+            return merged_payload
+
+        if tool_name == 'sales.update_invoice':
+            if _message_implies_add_line(user_message):
+                lines = await parse_sales_lines(
+                    self._backend_client,
+                    auth,
+                    user_message,
+                    invoice_id='',
+                )
+                if lines:
+                    merged_payload['lineOps'] = _merge_line_ops(
+                        merged_payload.get('lineOps'),
+                        [{'op': 'add', 'values': line} for line in lines],
+                    )
+            quantity_ops = _extract_quantity_change_ops(user_message)
+            if quantity_ops:
+                merged_payload['lineOps'] = _merge_line_ops(merged_payload.get('lineOps'), quantity_ops)
+            remove_ops = _extract_remove_line_ops(user_message)
+            if remove_ops:
+                merged_payload['lineOps'] = _merge_line_ops(merged_payload.get('lineOps'), remove_ops)
+            ordinal_line_ref = await self._resolve_existing_order_line_ref(
+                auth=auth,
+                tool_name=tool_name,
+                updated_payload=merged_payload,
+                user_message=user_message,
+            )
+            ordinal_quantity_change = _extract_ordinal_line_quantity_change(user_message)
+            if ordinal_line_ref and ordinal_quantity_change is not None:
+                merged_payload['lineOps'] = _merge_line_ops(
+                    merged_payload.get('lineOps'),
+                    [{'op': 'change_qty', 'lineRef': ordinal_line_ref, 'qty': ordinal_quantity_change[1]}],
+                )
+            descriptive_quantity = _extract_line_quantity_value(user_message)
+            if ordinal_line_ref and ordinal_quantity_change is None and descriptive_quantity is not None:
+                merged_payload['lineOps'] = _merge_line_ops(
+                    merged_payload.get('lineOps'),
+                    [{'op': 'change_qty', 'lineRef': ordinal_line_ref, 'qty': descriptive_quantity}],
+                )
+            ordinal_remove = _extract_ordinal_line_remove(user_message)
+            if ordinal_line_ref and ordinal_remove is not None:
+                merged_payload['lineOps'] = _merge_line_ops(
+                    merged_payload.get('lineOps'),
+                    [{'op': 'remove', 'lineRef': ordinal_line_ref}],
+                )
+            if ordinal_line_ref and ordinal_remove is None and not remove_ops and _message_implies_remove_line(user_message):
+                merged_payload['lineOps'] = _merge_line_ops(
+                    merged_payload.get('lineOps'),
+                    [{'op': 'remove', 'lineRef': ordinal_line_ref}],
+                )
+            return merged_payload
+
+        if tool_name == 'purchasing.receive_po':
+            location = await match_location(self._backend_client, auth, user_message)
+            if location:
+                merged_payload['locationId'] = location['id']
+            po_id = str(merged_payload.get('poId') or '')
+            lines = await parse_po_lines(
+                self._backend_client,
+                auth,
+                user_message,
+                po_id=po_id,
+                allow_missing_cost=True,
+            )
+            if lines:
+                merged_payload['lines'] = lines
+            return merged_payload
+
+        if tool_name == 'sales.dispatch_invoice':
+            location = await match_location(self._backend_client, auth, user_message)
+            if location:
+                merged_payload['locationId'] = location['id']
+            return merged_payload
+
+        return merged_payload
+
+    async def _recover_sparse_mutation_payload(
+        self,
+        *,
+        auth: AuthContext,
+        user_message: str,
+        primary_intent: str,
+        current_entities: dict[str, object],
+    ) -> tuple[str, dict[str, object]] | None:
+        recovered: dict[str, object] = {}
+
+        if primary_intent == 'purchasing.update_po':
+            po_ref = _extract_purchase_order_reference(user_message)
+            if po_ref:
+                recovered['poId'] = po_ref
+                try:
+                    recovered['poId'] = await EntityResolver(self._backend_client, auth).purchase_order(po_ref)
+                except ValueError:
+                    pass
+            date_value = _parse_iso_date_from_message(user_message)
+            if date_value:
+                recovered['expectedDate'] = date_value
+            if _message_implies_add_line(user_message):
+                lines = await parse_po_lines(
+                    self._backend_client,
+                    auth,
+                    user_message,
+                    po_id='',
+                    allow_missing_cost=True,
+                )
+                if lines:
+                    recovered['lineOps'] = [{'op': 'add', 'values': line} for line in lines]
+            quantity_ops = _extract_quantity_change_ops(user_message)
+            if quantity_ops:
+                recovered['lineOps'] = _merge_line_ops(recovered.get('lineOps'), quantity_ops)
+            remove_ops = _extract_remove_line_ops(user_message)
+            if remove_ops:
+                recovered['lineOps'] = _merge_line_ops(recovered.get('lineOps'), remove_ops)
+            recovered_po_id = str(recovered.get('poId') or '').strip()
+            if recovered_po_id:
+                line_ref = await self._resolve_existing_order_line_ref(
+                    auth=auth,
+                    tool_name=primary_intent,
+                    updated_payload={'poId': recovered_po_id},
+                    user_message=user_message,
+                )
+                descriptive_quantity = _extract_line_quantity_value(user_message)
+                if line_ref and descriptive_quantity is not None and not quantity_ops:
+                    recovered['lineOps'] = _merge_line_ops(
+                        recovered.get('lineOps'),
+                        [{'op': 'change_qty', 'lineRef': line_ref, 'qty': descriptive_quantity}],
+                    )
+                if line_ref and _message_implies_remove_line(user_message) and not remove_ops:
+                    recovered['lineOps'] = _merge_line_ops(
+                        recovered.get('lineOps'),
+                        [{'op': 'remove', 'lineRef': line_ref}],
+                    )
+            if recovered.get('poId') and any(key in recovered for key in ('expectedDate', 'lineOps')):
+                return primary_intent, recovered
+            return None
+
+        if primary_intent == 'purchasing.cancel_po':
+            po_ref = _extract_purchase_order_reference(user_message)
+            if po_ref:
+                return primary_intent, {'poId': po_ref, 'confirm': True}
+            return None
+
+        if primary_intent == 'purchasing.close_po':
+            po_ref = _extract_purchase_order_reference(user_message)
+            if po_ref:
+                return primary_intent, {'poId': po_ref, 'confirm': True}
+            return None
+
+        if primary_intent == 'purchasing.receive_po':
+            po_ref = _extract_purchase_order_reference(user_message)
+            if po_ref:
+                recovered['poId'] = po_ref
+            location = await match_location(self._backend_client, auth, user_message)
+            if location:
+                recovered['locationId'] = location['id']
+            lines = await parse_po_lines(
+                self._backend_client,
+                auth,
+                user_message,
+                po_id='',
+                allow_missing_cost=True,
+            )
+            if lines:
+                recovered['lines'] = lines
+            if 'poId' in recovered and ('locationId' in recovered or 'lines' in recovered):
+                recovered['confirm'] = True
+                return primary_intent, recovered
+            return None
+
+        if primary_intent == 'sales.update_invoice':
+            invoice_ref = _extract_invoice_reference(user_message)
+            if invoice_ref:
+                recovered['invoiceId'] = invoice_ref
+                try:
+                    recovered['invoiceId'] = await EntityResolver(self._backend_client, auth).invoice(invoice_ref)
+                except ValueError:
+                    pass
+            if _message_implies_add_line(user_message):
+                lines = await parse_sales_lines(
+                    self._backend_client,
+                    auth,
+                    user_message,
+                    invoice_id='',
+                )
+                if lines:
+                    recovered['lineOps'] = [{'op': 'add', 'values': line} for line in lines]
+            quantity_ops = _extract_quantity_change_ops(user_message)
+            if quantity_ops:
+                recovered['lineOps'] = _merge_line_ops(recovered.get('lineOps'), quantity_ops)
+            remove_ops = _extract_remove_line_ops(user_message)
+            if remove_ops:
+                recovered['lineOps'] = _merge_line_ops(recovered.get('lineOps'), remove_ops)
+            recovered_invoice_id = str(recovered.get('invoiceId') or '').strip()
+            if recovered_invoice_id:
+                line_ref = await self._resolve_existing_order_line_ref(
+                    auth=auth,
+                    tool_name=primary_intent,
+                    updated_payload={'invoiceId': recovered_invoice_id},
+                    user_message=user_message,
+                )
+                descriptive_quantity = _extract_line_quantity_value(user_message)
+                if line_ref and descriptive_quantity is not None and not quantity_ops:
+                    recovered['lineOps'] = _merge_line_ops(
+                        recovered.get('lineOps'),
+                        [{'op': 'change_qty', 'lineRef': line_ref, 'qty': descriptive_quantity}],
+                    )
+                if line_ref and _message_implies_remove_line(user_message) and not remove_ops:
+                    recovered['lineOps'] = _merge_line_ops(
+                        recovered.get('lineOps'),
+                        [{'op': 'remove', 'lineRef': line_ref}],
+                    )
+            if recovered.get('invoiceId') and recovered.get('lineOps'):
+                return primary_intent, recovered
+            return None
+
+        if primary_intent == 'sales.cancel_invoice':
+            invoice_ref = _extract_invoice_reference(user_message)
+            if invoice_ref:
+                return primary_intent, {'invoiceId': invoice_ref, 'confirm': True}
+            return None
+
+        if primary_intent == 'sales.dispatch_invoice':
+            invoice_ref = _extract_invoice_reference(user_message)
+            if invoice_ref:
+                recovered['invoiceId'] = invoice_ref
+            location = await match_location(self._backend_client, auth, user_message)
+            if location:
+                recovered['locationId'] = location['id']
+            if 'invoiceId' in recovered and 'locationId' in recovered:
+                recovered['confirm'] = True
+                return primary_intent, recovered
+            return None
+
+        if primary_intent == 'purchasing.get_po':
+            po_ref = _extract_purchase_order_reference(user_message)
+            if po_ref:
+                return primary_intent, {'poId': po_ref}
+            return None
+
+        if primary_intent == 'sales.get_invoice':
+            invoice_ref = _extract_invoice_reference(user_message)
+            if invoice_ref:
+                return primary_intent, {'invoiceId': invoice_ref}
+            return None
+
+        del current_entities
+        return None
 
     async def _prepare_confirmation(
         self,
@@ -944,13 +1941,25 @@ class AgentRuntimeService:
         emit: EventSink,
     ) -> RuntimeOutcome:
         active_approval_id = current_entities.get('activeApprovalId')
+        existing_tool_name = str(current_entities.get('toolName') or '')
         has_pending_approval = (
             isinstance(active_approval_id, str)
             and bool(active_approval_id)
             and current_entities.get('activeApprovalStatus') == 'pending'
+            and existing_tool_name == tool_name
         )
         try:
             prepared_arguments = await catalog.prepare(tool_name, tool_arguments)
+        except ToolSchemaValidationError as exc:
+            return self._clarification_outcome_from_schema_error(
+                current_entities={
+                    **current_entities,
+                    'toolName': tool_name,
+                    'executionPayload': tool_arguments,
+                },
+                required=exc.required_fields,
+                prompt=exc.prompt,
+            )
         except ToolPreparationError as exc:
             required = [str(item) for item in exc.missing_fields]
             emit(
@@ -970,10 +1979,7 @@ class AgentRuntimeService:
                 'toolName': tool_name,
                 'executionPayload': tool_arguments,
             }
-            next_entities = mark_task_status(
-                apply_task_context(draft_entities, increment_clarification_count(task_context_from_entities(draft_entities))),
-                'drafting',
-            )
+            next_entities = self._clarification_entities(draft_entities, required)
             return RuntimeOutcome(
                 blocks=render_clarification(exc.prompt, required),
                 status=WorkflowStatus.NEEDS_INPUT,
@@ -995,8 +2001,14 @@ class AgentRuntimeService:
             confirmation_prompt = 'Review these details and confirm. The request will then be submitted for approval.'
         else:
             confirmation_prompt = 'Review these details and confirm to continue.'
+        preview_warnings = await self._build_confirmation_warnings(
+            auth=auth,
+            tool_name=tool_name,
+            prepared_arguments=prepared_arguments,
+        )
 
         enriched_task_context = task_context_from_entities(state_update.extracted_entities)
+        enriched_task_context['missingFields'] = []
         enriched_entities = dict(enriched_task_context.get('entities') or {})
         enriched_entities.update(
             self._derived_context_entities(
@@ -1021,7 +2033,9 @@ class AgentRuntimeService:
             'preview': {
                 'tool': tool_name,
                 'arguments': tool_arguments,
+                'preparedArguments': prepared_arguments,
                 'taskContext': enriched_task_context,
+                'warnings': preview_warnings,
             },
             'approvalRequired': evaluation.requires_approval,
             'approvalReason': evaluation.reason,
@@ -1049,14 +2063,86 @@ class AgentRuntimeService:
             blocks=render_confirmation_required(
                 message=message_hint,
                 tool_name=tool_name,
-                tool_arguments=tool_arguments,
+                tool_arguments=prepared_arguments,
                 approval_required=evaluation.requires_approval,
                 confirmation_prompt=confirmation_prompt,
+                actor=auth.email,
+                warnings=preview_warnings,
             ),
             status=WorkflowStatus.AWAITING_CONFIRMATION,
             current_task='awaiting_confirmation',
             extracted_entities=next_entities,
         )
+
+    def _clarification_outcome_from_schema_error(
+        self,
+        *,
+        current_entities: dict[str, object],
+        required: list[str],
+        prompt: str,
+    ) -> RuntimeOutcome:
+        next_entities = self._clarification_entities(current_entities, required)
+        return RuntimeOutcome(
+            blocks=render_clarification(prompt, required),
+            status=WorkflowStatus.NEEDS_INPUT,
+            current_task='clarification_requested',
+            extracted_entities=next_entities,
+            missing_fields=required,
+        )
+
+    @staticmethod
+    def _clarification_entities(current_entities: dict[str, object], required: list[str]) -> dict[str, object]:
+        task_context = increment_clarification_count(task_context_from_entities(current_entities))
+        task_context['missingFields'] = list(required)
+        entities = dict(task_context.get('entities') or {})
+        tool_name = str(current_entities.get('toolName') or '')
+        execution_payload = current_entities.get('executionPayload')
+        if isinstance(execution_payload, dict):
+            for field in _WRITE_TOOL_ENTITY_FIELDS.get(tool_name, ()):
+                value = execution_payload.get(field)
+                if _has_meaningful_value(value):
+                    entities[field] = value
+        task_context['entities'] = entities
+        return mark_task_status(apply_task_context(current_entities, task_context), 'drafting')
+
+    @staticmethod
+    def _merge_follow_up_entities_into_payload(
+        *,
+        tool_name: str,
+        updated_payload: dict[str, object],
+        task_entities: dict[str, object],
+    ) -> dict[str, object]:
+        if tool_name != 'products.create_product':
+            return updated_payload
+
+        merged_payload = dict(updated_payload)
+        product = dict(merged_payload.get('product') or {})
+        if task_entities.get('styleCode'):
+            product['styleCode'] = task_entities['styleCode']
+        if task_entities.get('name'):
+            product['name'] = task_entities['name']
+        if task_entities.get('basePrice') is not None:
+            product['basePrice'] = task_entities['basePrice']
+        if product:
+            merged_payload['product'] = product
+        return merged_payload
+
+    @staticmethod
+    def _merge_clarification_task_entities_into_payload(
+        *,
+        tool_name: str,
+        updated_payload: dict[str, object],
+        task_entities: dict[str, object],
+    ) -> dict[str, object]:
+        merged_payload = dict(updated_payload)
+        writable_fields = set(_WRITE_TOOL_ENTITY_FIELDS.get(tool_name, ()))
+        for key, value in task_entities.items():
+            if value is None:
+                continue
+            if key in writable_fields and _has_meaningful_value(merged_payload.get(key)):
+                continue
+            merged_payload[key] = value
+        return merged_payload
 
     async def _run_phase(
         self,
@@ -1098,6 +2184,34 @@ class AgentRuntimeService:
         )
         return result
 
+    async def _record_audit_event(
+        self,
+        *,
+        auth: AuthContext,
+        conversation_id: UUID,
+        workflow_id: UUID,
+        event_type: str,
+        payload: dict[str, object],
+        tool_name: str | None = None,
+        approval_id: str | None = None,
+    ) -> None:
+        if self._audit_service is None:
+            return
+        try:
+            await self._audit_service.record(
+                tenant_id=auth.tenant_id,
+                user_id=auth.id,
+                actor_email=auth.email,
+                event_type=event_type,
+                conversation_id=str(conversation_id),
+                workflow_id=str(workflow_id),
+                approval_id=approval_id,
+                tool_name=tool_name,
+                payload=payload,
+            )
+        except Exception:
+            logger.exception('Failed to persist runtime audit event %s', event_type)
+
     def _schema_catalog_for_state(
         self,
         catalog: SemanticToolCatalog,
@@ -1115,7 +2229,8 @@ class AgentRuntimeService:
         tool_arguments: dict[str, object],
         current_entities: dict[str, object],
     ) -> dict[str, object]:
-        if tool_name != 'master.create_location':
+        entity_fields = _WRITE_TOOL_ENTITY_FIELDS.get(tool_name)
+        if entity_fields is None:
             return tool_arguments
 
         task_context = task_context_from_entities(current_entities)
@@ -1123,12 +2238,53 @@ class AgentRuntimeService:
         if not isinstance(entities, dict):
             return {}
 
-        sanitized = {
-            key: entities[key]
-            for key in ('name', 'code', 'type', 'address', 'status')
-            if entities.get(key) is not None
-        }
+        if tool_name == 'master.create_location':
+            sanitized = {key: entities[key] for key in entity_fields if entities.get(key) is not None}
+            raw_type = tool_arguments.get('type')
+            if 'type' not in sanitized and isinstance(raw_type, str) and raw_type.strip():
+                sanitized['type'] = raw_type.strip()
+            return sanitized
+        else:
+            sanitized = dict(tool_arguments)
+            for key in entity_fields:
+                value = entities.get(key)
+                if value is not None:
+                    sanitized[key] = value
+
+        required_fields = _WRITE_TOOL_REQUIRED_FIELDS.get(tool_name, ())
+        for key in required_fields:
+            value = sanitized.get(key)
+            if value is None:
+                return {}
+            if isinstance(value, str) and not value.strip():
+                return {}
+            if isinstance(value, list) and not value:
+                return {}
         return sanitized
+
+    @staticmethod
+    def _tool_arguments_need_clarification(*, tool_name: str, tool_arguments: dict[str, object]) -> bool:
+        if tool_name == 'master.create_location':
+            return not tool_arguments
+        if tool_name == 'purchasing.receive_po':
+            return not (
+                isinstance(tool_arguments.get('poId'), str)
+                and bool(str(tool_arguments.get('poId') or '').strip())
+                and isinstance(tool_arguments.get('locationId'), str)
+                and bool(str(tool_arguments.get('locationId') or '').strip())
+            )
+        required_fields = _WRITE_TOOL_REQUIRED_FIELDS.get(tool_name)
+        if required_fields is None:
+            return False
+        for key in required_fields:
+            value = tool_arguments.get(key)
+            if value is None:
+                return True
+            if isinstance(value, str) and not value.strip():
+                return True
+            if isinstance(value, list) and not value:
+                return True
+        return False
 
     @staticmethod
     def _should_bypass_tool_planning_for_ambiguous_message(
@@ -1172,19 +2328,191 @@ class AgentRuntimeService:
             'acknowledges their message, and invites them to continue.'
         )
 
+    @classmethod
+    def _start_compound_sequence(
+        cls,
+        *,
+        user_message: str,
+        extracted_entities: dict[str, object],
+        workflow_status: WorkflowStatus | None,
+    ) -> tuple[str, dict[str, object]]:
+        if workflow_status in {
+            WorkflowStatus.NEEDS_INPUT,
+            WorkflowStatus.AWAITING_CONFIRMATION,
+            WorkflowStatus.AWAITING_APPROVAL,
+        }:
+            return user_message, extracted_entities
+        existing_queue = extracted_entities.get('compoundQueue')
+        if isinstance(existing_queue, list) and existing_queue:
+            return user_message, extracted_entities
+
+        clauses = cls._split_compound_message(user_message)
+        if len(clauses) < 2:
+            return user_message, extracted_entities
+
+        queued_entities = dict(extracted_entities)
+        queued_entities['compoundQueue'] = clauses[1:]
+        return clauses[0], queued_entities
+
+    @classmethod
+    def _split_compound_message(cls, user_message: str) -> list[str]:
+        normalized = ' '.join(user_message.strip().split())
+        if not normalized:
+            return []
+
+        clauses = [
+            part.strip(' ,;')
+            for part in _COMPOUND_SEQUENCE_SPLIT_PATTERN.split(normalized)
+            if isinstance(part, str) and part.strip(' ,;')
+        ]
+        if len(clauses) < 2:
+            return [normalized]
+        if not all(_COMPOUND_SEQUENCE_ACTION_PATTERN.search(part) for part in clauses):
+            return [normalized]
+        return clauses
+
+    @staticmethod
+    def _tool_result_has_no_matches(tool_result: dict[str, object]) -> bool:
+        rows = tool_result.get('rows')
+        return isinstance(rows, list) and len(rows) == 0
+
     @staticmethod
     def _fallback_clarification_for_intent(primary_intent: str) -> tuple[str, list[str]]:
-        if primary_intent == 'sales.create_invoice':
-            return (
-                'Reply with the customer plus product, color, size, and quantity for each sales order line.',
-                ['customer_id', 'lines'],
-            )
+        # Products
         if primary_intent == 'products.create_product':
             return (
                 'Reply with the product name, style code, base price, color, and size details.',
                 ['style_code', 'name', 'base_price', 'color_name', 'size_labels'],
             )
-        return ('Please restate the action with the key details I should use.', [])
+        if primary_intent == 'products.update_product':
+            return (
+                'Which product should I update, and what should change (name, price, category, or variant details)?',
+                ['product_id', 'changes'],
+            )
+
+        # Sales
+        if primary_intent == 'sales.create_invoice':
+            return (
+                'Reply with the customer plus product, color, size, and quantity for each sales order line.',
+                ['customer_id', 'lines'],
+            )
+        if primary_intent == 'sales.dispatch_invoice':
+            return (
+                'Which sales order should I dispatch, and from which location?',
+                ['sales_order_id', 'location_id'],
+            )
+        if primary_intent == 'sales.cancel_invoice':
+            return ('Which sales order should I cancel?', ['sales_order_id'])
+
+        # Purchasing
+        if primary_intent == 'purchasing.create_po':
+            return (
+                'Reply with the supplier name and PO lines in the format `SKUCODE/SIZE xQTY @UNIT_COST`, separated by commas.',
+                ['supplier_id', 'lines'],
+            )
+        if primary_intent == 'purchasing.receive_po':
+            return (
+                'Which purchase order should I receive, and which location should it go to?',
+                ['po_id', 'location_id'],
+            )
+        if primary_intent == 'purchasing.close_po':
+            return ('Which purchase order should I close?', ['po_id'])
+
+        # Inventory movements
+        if primary_intent == 'inventory.transfer_stock':
+            return (
+                'Reply with the SKU/size (e.g. `SKUCODE/XL`), quantity, source location, and destination location.',
+                ['sku_and_size', 'quantity', 'from_location_id', 'to_location_id'],
+            )
+        if primary_intent in {'inventory.adjust_stock', 'inventory.receive_stock', 'inventory.write_off_stock'}:
+            return (
+                'Reply with the SKU/size (e.g. `SKUCODE/XL`), quantity, and location.',
+                ['sku_and_size', 'quantity', 'location_id'],
+            )
+        if primary_intent == 'inventory.stock_on_hand':
+            return (
+                'Which product, SKU, or location would you like stock details for?',
+                ['productName'],
+            )
+
+        # Suppliers
+        if primary_intent == 'master.create_supplier':
+            return (
+                'Reply with the supplier name, and optionally email, phone, and address.',
+                ['name'],
+            )
+        if primary_intent == 'master.update_supplier':
+            return (
+                'Which supplier should I update, and what should change (name, email, phone, or address)?',
+                ['supplier_id', 'patch'],
+            )
+        if primary_intent == 'master.delete_supplier':
+            return ('Which supplier should I delete?', ['supplier_id'])
+
+        # Customers
+        if primary_intent == 'master.create_customer':
+            return (
+                'Reply with the customer name, and optionally email, phone, and address.',
+                ['name'],
+            )
+        if primary_intent == 'master.update_customer':
+            return (
+                'Which customer should I update, and what should change (name, email, phone, or address)?',
+                ['customer_id', 'patch'],
+            )
+        if primary_intent == 'master.delete_customer':
+            return ('Which customer should I delete?', ['customer_id'])
+
+        # Locations
+        if primary_intent == 'master.create_location':
+            return (
+                'Reply with the location name, code, and type (warehouse, store, or outlet). Address and status are optional.',
+                ['name', 'code', 'type'],
+            )
+        if primary_intent == 'master.update_location':
+            return (
+                'Which location should I update, and what should change?',
+                ['location_id', 'patch'],
+            )
+        if primary_intent == 'master.delete_location':
+            return ('Which location should I delete?', ['location_id'])
+
+        # Reporting
+        if primary_intent == 'reporting.stock_summary':
+            return (
+                'Which report do you need: stock summary, movement, purchase orders, or receipts?',
+                ['report_type'],
+            )
+
+        return ('Could you clarify what you\'d like me to do? Please include the key details for your request.', [])
+
+    @classmethod
+    def _clarification_directive(
+        cls,
+        *,
+        primary_intent: str,
+        suggested_prompt: object,
+    ) -> str:
+        prompt = str(suggested_prompt or '').strip()
+        if prompt and not _is_generic_clarification_prompt(prompt):
+            return prompt
+        fallback_prompt, _missing = cls._fallback_clarification_for_intent(primary_intent)
+        return fallback_prompt
+
+    @classmethod
+    def _clarification_prompt_and_required(
+        cls,
+        *,
+        primary_intent: str,
+        suggested_prompt: object,
+        suggested_required: object,
+    ) -> tuple[str, list[str]]:
+        required = [str(item) for item in suggested_required or [] if str(item)]
+        prompt = str(suggested_prompt or '').strip()
+        if prompt and not _is_generic_clarification_prompt(prompt):
+            return prompt, required
+        fallback_prompt, fallback_required = cls._fallback_clarification_for_intent(primary_intent)
+        return fallback_prompt, (required or fallback_required)
 
     @staticmethod
     def _derived_context_entities(
@@ -1195,11 +2523,12 @@ class AgentRuntimeService:
         resolved_entities: object = None,
     ) -> dict[str, object]:
         entities: dict[str, object] = {}
+        result_payload = AgentRuntimeService._tool_result_payload(tool_result)
 
         if tool_name == 'inventory.stock_on_hand':
             if isinstance(tool_arguments.get('productName'), str) and tool_arguments.get('productName'):
                 entities['productName'] = str(tool_arguments['productName'])
-            rows = tool_result.get('rows') if isinstance(tool_result, dict) else None
+            rows = result_payload.get('rows')
             if isinstance(rows, list):
                 product_names = sorted(
                     {
@@ -1230,6 +2559,126 @@ class AgentRuntimeService:
                 if size_labels:
                     entities['sizeLabels'] = size_labels
                     entities['sizeLabel'] = size_labels[0]
+
+        if tool_name == 'master.create_customer':
+            customer_name = str(tool_arguments.get('name') or result_payload.get('name') or '').strip()
+            customer_id = str(result_payload.get('id') or result_payload.get('customerId') or '').strip()
+            if customer_name:
+                entities['customerName'] = customer_name
+            if customer_id:
+                entities['customerId'] = customer_id
+
+        if tool_name == 'master.create_supplier':
+            supplier_name = str(tool_arguments.get('name') or result_payload.get('name') or '').strip()
+            supplier_id = str(result_payload.get('id') or result_payload.get('supplierId') or '').strip()
+            if supplier_name:
+                entities['supplierName'] = supplier_name
+            if supplier_id:
+                entities['supplierId'] = supplier_id
+
+        if tool_name == 'master.create_location':
+            location_name = str(tool_arguments.get('name') or result_payload.get('name') or '').strip()
+            location_id = str(result_payload.get('id') or result_payload.get('locationId') or '').strip()
+            if location_name:
+                entities['locationName'] = location_name
+            if location_id:
+                entities['locationId'] = location_id
+
+        if tool_name == 'purchasing.create_po':
+            supplier_id = str(tool_arguments.get('supplierId') or result_payload.get('supplierId') or '').strip()
+            supplier_name = str(tool_arguments.get('supplierName') or result_payload.get('supplierName') or '').strip()
+            if supplier_id:
+                entities['supplierId'] = supplier_id
+            if supplier_name:
+                entities['supplierName'] = supplier_name
+            po_id = str(result_payload.get('id') or result_payload.get('poId') or '').strip()
+            po_number = str(result_payload.get('poNumber') or result_payload.get('number') or '').strip()
+            if po_id:
+                entities['poId'] = po_id
+            if po_number:
+                entities['poNumber'] = po_number
+
+        if tool_name == 'sales.create_invoice':
+            customer_id = str(tool_arguments.get('customerId') or result_payload.get('customerId') or '').strip()
+            customer_name = str(tool_arguments.get('customerName') or result_payload.get('customerName') or '').strip()
+            if customer_id:
+                entities['customerId'] = customer_id
+            if customer_name:
+                entities['customerName'] = customer_name
+            invoice_id = str(result_payload.get('id') or result_payload.get('invoiceId') or '').strip()
+            invoice_number = str(
+                result_payload.get('invoiceNumber') or result_payload.get('salesOrderNumber') or result_payload.get('number') or ''
+            ).strip()
+            if invoice_id:
+                entities['invoiceId'] = invoice_id
+            if invoice_number:
+                entities['invoiceNumber'] = invoice_number
+
+        if tool_name == 'purchasing.get_po':
+            supplier_id = str(result_payload.get('supplierId') or '').strip()
+            supplier_name = str(result_payload.get('supplierName') or '').strip()
+            po_id = str(result_payload.get('id') or '').strip()
+            po_number = str(result_payload.get('poNumber') or result_payload.get('number') or '').strip()
+            if supplier_id:
+                entities['supplierId'] = supplier_id
+            if supplier_name:
+                entities['supplierName'] = supplier_name
+            if po_id:
+                entities['poId'] = po_id
+            if po_number:
+                entities['poNumber'] = po_number
+
+        if tool_name == 'sales.get_invoice':
+            customer_id = str(result_payload.get('customerId') or '').strip()
+            customer_name = str(result_payload.get('customerName') or '').strip()
+            invoice_id = str(result_payload.get('id') or '').strip()
+            invoice_number = str(
+                result_payload.get('invoiceNumber') or result_payload.get('salesOrderNumber') or result_payload.get('number') or ''
+            ).strip()
+            if customer_id:
+                entities['customerId'] = customer_id
+            if customer_name:
+                entities['customerName'] = customer_name
+            if invoice_id:
+                entities['invoiceId'] = invoice_id
+            if invoice_number:
+                entities['invoiceNumber'] = invoice_number
+
+        if tool_name == 'purchasing.list_pos':
+            rows = result_payload.get('items')
+            if isinstance(rows, list) and len(rows) == 1 and isinstance(rows[0], dict):
+                row = rows[0]
+                supplier_id = str(row.get('supplierId') or '').strip()
+                supplier_name = str(row.get('supplierName') or row.get('supplier_name') or '').strip()
+                po_id = str(row.get('id') or '').strip()
+                po_number = str(row.get('poNumber') or row.get('number') or '').strip()
+                if supplier_id:
+                    entities['supplierId'] = supplier_id
+                if supplier_name:
+                    entities['supplierName'] = supplier_name
+                if po_id:
+                    entities['poId'] = po_id
+                if po_number:
+                    entities['poNumber'] = po_number
+
+        if tool_name == 'sales.list_invoices':
+            rows = result_payload.get('items')
+            if isinstance(rows, list) and len(rows) == 1 and isinstance(rows[0], dict):
+                row = rows[0]
+                customer_id = str(row.get('customerId') or '').strip()
+                customer_name = str(row.get('customerName') or row.get('customer_name') or '').strip()
+                invoice_id = str(row.get('id') or '').strip()
+                invoice_number = str(
+                    row.get('invoiceNumber') or row.get('salesOrderNumber') or row.get('number') or ''
+                ).strip()
+                if customer_id:
+                    entities['customerId'] = customer_id
+                if customer_name:
+                    entities['customerName'] = customer_name
+                if invoice_id:
+                    entities['invoiceId'] = invoice_id
+                if invoice_number:
+                    entities['invoiceNumber'] = invoice_number
 
         if tool_name == 'products.create_product':
             product_payload = tool_arguments.get('product')
@@ -1281,6 +2730,15 @@ class AgentRuntimeService:
                     entities[key] = value
 
         return entities
+
+    @staticmethod
+    def _tool_result_payload(tool_result: dict[str, object] | None) -> dict[str, object]:
+        if not isinstance(tool_result, dict):
+            return {}
+        nested_result = tool_result.get('result')
+        if isinstance(nested_result, dict):
+            return nested_result
+        return tool_result
 
     @staticmethod
     def _merge_context_from_tool_interaction(

--- a/conversational-engine/src/conversational_engine/runtime/state_update.py
+++ b/conversational-engine/src/conversational_engine/runtime/state_update.py
@@ -355,9 +355,21 @@ async def resolve_state_update(
         primary_route=primary_route,
         primary_intent=primary_intent,
     ):
+        carryover_entities: dict[str, Any] = {}
+        if isinstance(prior_entities, dict):
+            if active_intent == 'master.create_supplier' and primary_intent == 'purchasing.create_po':
+                for key in ('supplierId', 'supplierName'):
+                    value = prior_entities.get(key)
+                    if value is not None:
+                        carryover_entities[key] = value
+            if active_intent == 'master.create_customer' and primary_intent == 'sales.create_invoice':
+                for key in ('customerId', 'customerName'):
+                    value = prior_entities.get(key)
+                    if value is not None:
+                        carryover_entities[key] = value
         extracted_entities = _clear_runtime_workflow_state(extracted_entities, task_context)
         task_context = fresh_task_context()
-        merged_entities = dict(patches)
+        merged_entities = {**carryover_entities, **patches}
         if primary_intent == 'master.create_location':
             merged_entities.update(_extract_location_create_entities(action_text or text))
         if primary_intent in {'master.create_supplier', 'master.create_customer'}:
@@ -843,19 +855,37 @@ def _extract_contact_create_entities(text: str) -> dict[str, Any]:
     for field in _CONTACT_FIELDS:
         if field in extracted:
             continue
-        m = re.search(
-            rf'\b{field}\b\s*[:=][;,]?\s*([^\n,;:]+?){_FIELD_BOUNDARY}',
-            working,
-            re.IGNORECASE,
-        )
+        if field == 'address':
+            m = re.search(
+                r'\baddress\b(?:\s*[:=][;,]?\s*|\s+\bis\b\s+|\s+)(.+?)(?=\s*(?:$|;|\b(?:name|email|phone|status)\b))',
+                working,
+                re.IGNORECASE,
+            )
+        else:
+            m = re.search(
+                rf'\b{field}\b(?:\s*[:=][;,]?\s*|\s+\bis\b\s+)([^\n,;:]+?){_FIELD_BOUNDARY}',
+                working,
+                re.IGNORECASE,
+            )
         if m:
             value = m.group(1).strip().strip('"\'')
             if value:
                 extracted[field] = value
 
+    if 'name' not in extracted:
+        named_match = re.search(
+            r'\b(?:name|named|called)\b\s*[:=]?\s*"?(.+?)"?(?=\s*(?:$|,|;|\b(?:with\s+email|email|phone|address|status)\b))',
+            working,
+            re.IGNORECASE,
+        )
+        if named_match:
+            value = named_match.group(1).strip().strip('"\'')
+            if value:
+                extracted['name'] = value
+
     # ── bare name fallback ─────────────────────────────────────────────────────
     if 'name' not in extracted:
-        _COMMAND_WORDS = r'\b(create|add|new|onboard|register|supplier|customer|vendor|client)\b'
+        _COMMAND_WORDS = r'\b(create|add|new|onboard|register|supplier|customer|vendor|client|named|called)\b'
         # Also strip any remaining "field:;" style label artifacts before extracting the bare name.
         _LABEL_ARTIFACTS = r'\b(?:name|email|phone|address|status)\b\s*[:=][;,]?\s*'
         candidate = re.sub(_COMMAND_WORDS, '', working, flags=re.IGNORECASE)
@@ -875,7 +905,7 @@ def _extract_contact_create_entities(text: str) -> dict[str, Any]:
             'use same',
             'use same details',
             'again',
-        }:
+        } and not re.search(r'\b(?:phone|email|address|status)\b', candidate, re.IGNORECASE):
             extracted['name'] = candidate
 
     return extracted

--- a/conversational-engine/src/conversational_engine/runtime/state_update.py
+++ b/conversational-engine/src/conversational_engine/runtime/state_update.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from conversational_engine.retrieval.service import RetrievalService
+from conversational_engine.utils.casing import to_camel
+from conversational_engine.utils.time import utc_now
 
 if TYPE_CHECKING:
     from conversational_engine.agents.state_updater import StateUpdateAgent
@@ -22,6 +25,35 @@ _NAVIGATION_PREFIXES = (
     'show me ',
     'show ',
 )
+_INVENTORY_KEYWORDS = (
+    'stock',
+    'inventory',
+    'product',
+    'products',
+    'sku',
+    'size',
+    'sizes',
+    'color',
+    'colors',
+    'purchase',
+    'supplier',
+    'customer',
+    'invoice',
+    'sales order',
+    'warehouse',
+    'location',
+    'report',
+    'movement',
+    'receipt',
+    'transfer',
+    'adjust',
+    'write off',
+    'category',
+    'brand',
+    'price',
+)
+_NON_DOMAIN_SMALL_TALK = ('hi', 'hello', 'thanks', 'thank you')
+_PENDING_TASK_TTL = timedelta(minutes=30)
 _MASTER_CREATE_VERBS = r'(create|add|new|onboard|register)'
 _MASTER_UPDATE_VERBS = r'(update|edit|change|rename)'
 _MASTER_DELETE_VERBS = r'(delete|remove)'
@@ -90,6 +122,22 @@ _MUTATION_PATTERNS: tuple[tuple[str, str], ...] = (
     ),
 )
 _READ_PATTERNS: tuple[tuple[str, str], ...] = (
+    (
+        'purchasing.list_pos',
+        r'\b(list|show|search|find)\b.*\b(open\s+)?(purchase orders|purchase order|pos|po)\b',
+    ),
+    (
+        'purchasing.get_po',
+        r'\b(status of|what(?:s| is) the status of|lines in|details of|inspect)\b.*\b(purchase order|po)\b',
+    ),
+    (
+        'sales.list_invoices',
+        r'\b(list|show|search|find)\b.*\b(open\s+)?(sales orders|sales order|invoices|invoice|sos|so)\b',
+    ),
+    (
+        'sales.get_invoice',
+        r'\b(status of|what(?:s| is) the status of|lines in|details of|inspect)\b.*\b(sales order|invoice|so)\b',
+    ),
     ('inventory.stock_on_hand', r'\b(stock|stock on hand|available)\b'),
     ('inventory.stock_on_hand', r'\b(size|sizes|variant|variants|color|colors)\b'),
     ('reporting.stock_summary', r'\b(summary|report)\b'),
@@ -116,7 +164,14 @@ def task_context_from_entities(extracted_entities: dict[str, Any]) -> dict[str, 
     if isinstance(existing, dict):
         context = dict(existing)
     else:
-        context = {'primaryRoute': None, 'primaryIntent': None}
+        pending_task = _active_pending_task(extracted_entities)
+        context = {
+            'primaryRoute': pending_task.get('route') if pending_task else None,
+            'primaryIntent': pending_task.get('intent') if pending_task else None,
+            'entities': dict(pending_task.get('entities') or {}) if pending_task else {},
+            'missingFields': list(pending_task.get('missingFields') or []) if pending_task else [],
+            'status': str(pending_task.get('status') or 'drafting') if pending_task else 'drafting',
+        }
     context.setdefault('primaryRoute', None)
     context.setdefault('primaryIntent', None)
     context.setdefault('entities', {})
@@ -128,6 +183,19 @@ def task_context_from_entities(extracted_entities: dict[str, Any]) -> dict[str, 
     return context
 
 
+def fresh_task_context() -> dict[str, Any]:
+    return {
+        'primaryRoute': None,
+        'primaryIntent': None,
+        'entities': {},
+        'missingFields': [],
+        'postActions': [],
+        'lastResolvedRoute': None,
+        'clarificationCount': 0,
+        'status': 'drafting',
+    }
+
+
 def apply_task_context(extracted_entities: dict[str, Any], task_context: dict[str, Any]) -> dict[str, Any]:
     merged = dict(extracted_entities)
     merged['taskContext'] = task_context
@@ -135,6 +203,7 @@ def apply_task_context(extracted_entities: dict[str, Any], task_context: dict[st
     if isinstance(entities, dict):
         for key, value in entities.items():
             merged[key] = value
+    _sync_pending_task(merged, task_context)
     return merged
 
 
@@ -153,6 +222,8 @@ def mark_task_status(
     updated = dict(extracted_entities)
     task_context = task_context_from_entities(updated)
     task_context['status'] = status
+    if status in {'awaiting_confirmation', 'awaiting_approval', 'completed'}:
+        task_context['missingFields'] = []
     if clear_post_actions:
         task_context['postActions'] = []
     updated['taskContext'] = task_context
@@ -256,11 +327,17 @@ async def resolve_state_update(
         primary_route = ROUTE_MIXED
         rationale = f'{rationale} Queued a post-action navigation step after the mutation succeeds.'
 
-    merged_entities.update(patches)
     active_intent = str(task_context.get('primaryIntent') or '')
+    merged_entities.update(patches)
     if primary_intent == 'master.create_location' or active_intent == 'master.create_location':
         merged_entities.update(_extract_location_create_entities(action_text or text))
-    if not is_workflow_edit and _should_continue_pending_mutation(
+    if (
+        primary_intent in {'master.create_supplier', 'master.create_customer'}
+        or active_intent in {'master.create_supplier', 'master.create_customer'}
+    ):
+        merged_entities.update(_extract_contact_create_entities(action_text or text))
+
+    if not is_workflow_edit and _should_continue_pending_task(
         text=action_text or text,
         task_context=task_context,
         route_fallback=route_fallback,
@@ -273,6 +350,19 @@ async def resolve_state_update(
         rationale = 'Applied this turn as missing-field input for the active workflow.'
         confidence = max(confidence, 0.91)
         used_memory = True
+    elif not is_workflow_edit and _should_reset_mutation_context(
+        task_context=task_context,
+        primary_route=primary_route,
+        primary_intent=primary_intent,
+    ):
+        extracted_entities = _clear_runtime_workflow_state(extracted_entities, task_context)
+        task_context = fresh_task_context()
+        merged_entities = dict(patches)
+        if primary_intent == 'master.create_location':
+            merged_entities.update(_extract_location_create_entities(action_text or text))
+        if primary_intent in {'master.create_supplier', 'master.create_customer'}:
+            merged_entities.update(_extract_contact_create_entities(action_text or text))
+
     task_context['primaryRoute'] = primary_route
     task_context['primaryIntent'] = primary_intent
     task_context['entities'] = merged_entities
@@ -293,7 +383,16 @@ async def resolve_state_update(
             task_context['postActions'] = [*existing_actions] if isinstance(existing_actions, list) else []
             task_context['postActions'].extend(new_post_actions)
 
-    task_context['missingFields'] = list(task_context.get('missingFields') or [])
+    # When continuing an active workflow, remove any missing fields that are
+    # now satisfied by the merged entities so the planner doesn't keep asking
+    # for them even after the user has supplied the values.
+    if is_workflow_edit:
+        task_context['missingFields'] = [
+            field for field in (task_context.get('missingFields') or [])
+            if not _entity_has_value(merged_entities, field)
+        ]
+    else:
+        task_context['missingFields'] = list(task_context.get('missingFields') or [])
     updated_entities = apply_task_context(extracted_entities, task_context)
     planner_message = _build_planner_message(
         original_message=text,
@@ -360,7 +459,25 @@ def _resolve_primary_route_and_intent(text: str) -> tuple[str, str, str, float]:
                 0.96,
             )
 
+    if _is_off_topic(normalized):
+        return (ROUTE_READ, 'off_topic', 'Detected a request outside the inventory domain.', 0.95)
+
     return (ROUTE_READ, 'inventory.stock_on_hand', 'Defaulted to a read workflow.', 0.42)
+
+
+def _is_off_topic(normalized: str) -> bool:
+    if not normalized:
+        return False
+    if normalized in _NON_DOMAIN_SMALL_TALK:
+        return False
+    if any(keyword in normalized for keyword in _INVENTORY_KEYWORDS):
+        return False
+    if any(normalized.startswith(prefix.strip()) for prefix in _NAVIGATION_PREFIXES):
+        return False
+    tokens = re.findall(r"[a-z0-9']+", normalized)
+    if len(tokens) <= 3:
+        return False
+    return True
 
 
 async def _resolve_navigation_rows(
@@ -492,7 +609,92 @@ def _extract_location_create_entities(text: str) -> dict[str, Any]:
     return extracted
 
 
-def _should_continue_pending_mutation(
+def _active_pending_task(extracted_entities: dict[str, Any]) -> dict[str, Any] | None:
+    raw = extracted_entities.get('pendingTask')
+    if not isinstance(raw, dict):
+        raw = extracted_entities.get('pending_task')
+    if not isinstance(raw, dict):
+        return None
+    updated_at = raw.get('updatedAt')
+    if not isinstance(updated_at, str):
+        return None
+    try:
+        age = utc_now() - datetime.fromisoformat(updated_at.replace('Z', '+00:00'))
+    except ValueError:
+        return None
+    if age > _PENDING_TASK_TTL:
+        return None
+    return raw
+
+
+def _sync_pending_task(extracted_entities: dict[str, Any], task_context: dict[str, Any]) -> None:
+    status = str(task_context.get('status') or '')
+    if status in {'completed', 'failed'}:
+        extracted_entities.pop('pendingTask', None)
+        extracted_entities.pop('pending_task', None)
+        return
+    primary_intent = str(task_context.get('primaryIntent') or '')
+    if not primary_intent:
+        extracted_entities.pop('pendingTask', None)
+        extracted_entities.pop('pending_task', None)
+        return
+    extracted_entities['pendingTask'] = {
+        'route': task_context.get('primaryRoute'),
+        'intent': primary_intent,
+        'entities': dict(task_context.get('entities') or {}),
+        'missingFields': list(task_context.get('missingFields') or []),
+        'status': status or 'drafting',
+        'updatedAt': utc_now().isoformat(),
+    }
+
+
+def _should_reset_mutation_context(
+    *,
+    task_context: dict[str, Any],
+    primary_route: str,
+    primary_intent: str,
+) -> bool:
+    active_route = str(task_context.get('primaryRoute') or '')
+    active_intent = str(task_context.get('primaryIntent') or '')
+    if active_route != ROUTE_MUTATION or primary_route != ROUTE_MUTATION:
+        return False
+    if not active_intent or not primary_intent:
+        return False
+    return active_intent != primary_intent
+
+
+def _clear_runtime_workflow_state(
+    extracted_entities: dict[str, Any],
+    task_context: dict[str, Any],
+) -> dict[str, Any]:
+    cleared = dict(extracted_entities)
+    entities = task_context.get('entities')
+    if isinstance(entities, dict):
+        for key in entities:
+            cleared.pop(key, None)
+
+    for key in (
+        'taskContext',
+        'pendingTask',
+        'pending_task',
+        'toolName',
+        'executionPayload',
+        'preview',
+        'approvalRequired',
+        'approvalReason',
+        'summary',
+        'activeApprovalId',
+        'activeApprovalStatus',
+        '_pendingActions',
+        '_pendingPrompt',
+        '_pendingApprovalUpdateOriginal',
+        '_approvalOperation',
+    ):
+        cleared.pop(key, None)
+    return cleared
+
+
+def _should_continue_pending_task(
     *,
     text: str,
     task_context: dict[str, Any],
@@ -503,23 +705,93 @@ def _should_continue_pending_mutation(
     active_route = str(task_context.get('primaryRoute') or '')
     active_intent = str(task_context.get('primaryIntent') or '')
     missing_fields = [str(item) for item in task_context.get('missingFields') or []]
-    if active_route != ROUTE_MUTATION or not active_intent or not missing_fields:
+    status = str(task_context.get('status') or '')
+    if active_route not in {ROUTE_MUTATION, ROUTE_READ} or not active_intent:
         return False
+    # A new mutation for a *different* intent starts a fresh workflow.
     if route_fallback == ROUTE_MUTATION and intent_fallback and intent_fallback != active_intent:
         return False
+    if not missing_fields:
+        normalized = _normalize(text)
+        return (
+            active_route == ROUTE_MUTATION
+            and status in {'drafting', 'awaiting_confirmation', 'awaiting_approval'}
+            and route_fallback != ROUTE_MUTATION
+            and bool(normalized)
+            and not normalized.endswith('?')
+            and _looks_like_mutation_follow_up(normalized)
+        )
+    # Always continue when an entity extracted from this turn satisfies a missing field.
     if any(_entity_has_value(merged_entities, field) for field in missing_fields):
         return True
     normalized = _normalize(text)
     if not normalized or normalized.endswith('?'):
         return False
-    return ':' in text or '\n' in text
+    # Structured input (key:value or multiline) is clearly a follow-up.
+    if ':' in text or '\n' in text:
+        return True
+    # When an active mutation workflow is waiting for input and the user's
+    # message didn't resolve to a competing mutation intent, treat any
+    # non-question reply as continuation — regardless of how many tokens it
+    # has.  This handles detailed follow-ups like
+    # "tshirt, tees-1202, base price 100, xl size, black color".
+    if active_route == ROUTE_MUTATION and route_fallback != ROUTE_MUTATION:
+        return True
+    # Legacy short-message heuristic for read workflows.
+    return len(re.findall(r"[a-z0-9']+", normalized)) <= 4
 
 
 def _entity_has_value(entities: dict[str, Any], field: str) -> bool:
-    value = entities.get(field)
-    if isinstance(value, str):
-        return bool(value.strip())
-    return value is not None
+    for key in _entity_field_aliases(field):
+        value = entities.get(key)
+        if isinstance(value, str) and value.strip():
+            return True
+        if value is not None:
+            return True
+    return False
+
+
+def _entity_field_aliases(field: str) -> tuple[str, ...]:
+    aliases = {
+        'sku_and_size': ('sizeId', 'skuCode', 'sizeLabel'),
+        'location_and_quantity': ('locationId', 'quantity'),
+        'color_name': ('colorName',),
+        'size_labels': ('sizeLabels',),
+        'base_price': ('basePrice',),
+        'style_code': ('styleCode',),
+        'product_id': ('productId',),
+        'supplier_id': ('supplierId',),
+        'customer_id': ('customerId',),
+        'po_id': ('poId',),
+        'invoice_id': ('invoiceId',),
+        'location_id': ('locationId',),
+        'from_location_id': ('fromLocationId',),
+        'to_location_id': ('toLocationId',),
+    }
+    return (field, to_camel(field), *aliases.get(field, ()))
+
+
+def _looks_like_mutation_follow_up(normalized: str) -> bool:
+    if any(char.isdigit() for char in normalized):
+        return True
+    return any(
+        keyword in normalized
+        for keyword in (
+            'item',
+            'items',
+            'qty',
+            'quantity',
+            'supplier',
+            'customer',
+            'product',
+            'sku',
+            'style',
+            'color',
+            'size',
+            'same supplier',
+            'same customer',
+        )
+    )
 
 
 def _looks_like_location_code(value: str) -> bool:
@@ -538,6 +810,75 @@ def _normalize_location_type(value: str) -> str | None:
     if collapsed == 'outlet':
         return 'outlet'
     return None
+
+
+def _extract_contact_create_entities(text: str) -> dict[str, Any]:
+    """Extract name/email/phone/address from a supplier or customer creation message.
+
+    Handles inputs like:
+      "raghu"
+      "name : raghu"
+      "name : raghubez email raghu@bez.com"
+      "raghu, raghu@example.com, +447700123456, 10 Baker St"
+    """
+    extracted: dict[str, Any] = {}
+    working = text.strip()
+
+    # ── email ──────────────────────────────────────────────────────────────────
+    email_match = re.search(r'\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b', working)
+    if email_match:
+        extracted['email'] = email_match.group(0)
+        working = (working[: email_match.start()] + ' ' + working[email_match.end() :]).strip()
+
+    # ── phone ──────────────────────────────────────────────────────────────────
+    phone_match = re.search(r'(?<!\w)(\+?[0-9][\d\s\-()]{6,15}[0-9])(?!\w)', working)
+    if phone_match:
+        extracted['phone'] = phone_match.group(1).strip()
+        working = (working[: phone_match.start()] + ' ' + working[phone_match.end() :]).strip()
+
+    # ── labelled fields (field : value  or  field = value) ────────────────────
+    # Allow optional stray punctuation after the separator, e.g. "name:; raghu" or "name:, raghu".
+    _CONTACT_FIELDS = ('name', 'email', 'phone', 'address', 'status')
+    _FIELD_BOUNDARY = r'(?=\s*(?:$|,|;|\b(?:name|email|phone|address|status)\b))'
+    for field in _CONTACT_FIELDS:
+        if field in extracted:
+            continue
+        m = re.search(
+            rf'\b{field}\b\s*[:=][;,]?\s*([^\n,;:]+?){_FIELD_BOUNDARY}',
+            working,
+            re.IGNORECASE,
+        )
+        if m:
+            value = m.group(1).strip().strip('"\'')
+            if value:
+                extracted[field] = value
+
+    # ── bare name fallback ─────────────────────────────────────────────────────
+    if 'name' not in extracted:
+        _COMMAND_WORDS = r'\b(create|add|new|onboard|register|supplier|customer|vendor|client)\b'
+        # Also strip any remaining "field:;" style label artifacts before extracting the bare name.
+        _LABEL_ARTIFACTS = r'\b(?:name|email|phone|address|status)\b\s*[:=][;,]?\s*'
+        candidate = re.sub(_COMMAND_WORDS, '', working, flags=re.IGNORECASE)
+        candidate = re.sub(_LABEL_ARTIFACTS, '', candidate, flags=re.IGNORECASE).strip(' ,;:')
+        normalized_candidate = _normalize(candidate)
+        if candidate and normalized_candidate not in {
+            'yes',
+            'yeah',
+            'yep',
+            'ok',
+            'okay',
+            'sure',
+            'same',
+            'same one',
+            'same details',
+            'same as before',
+            'use same',
+            'use same details',
+            'again',
+        }:
+            extracted['name'] = candidate
+
+    return extracted
 
 
 def _looks_like_location_creation_request(value: str) -> bool:

--- a/conversational-engine/src/conversational_engine/tools/catalog/__init__.py
+++ b/conversational-engine/src/conversational_engine/tools/catalog/__init__.py
@@ -5,6 +5,7 @@ from typing import Any
 from conversational_engine.clients.backend import BackendClient
 from conversational_engine.contracts.auth import AuthContext
 from conversational_engine.tools.definitions import SemanticTool
+from conversational_engine.tools.validation import ToolSchemaValidationError, validate_payload
 from .commerce import build_commerce_tools
 from .inventory import build_inventory_tools
 from .products import build_product_tools
@@ -12,9 +13,16 @@ from .resolvers import EntityResolver
 
 
 class SemanticToolCatalog:
-    def __init__(self, *, backend: BackendClient, auth: AuthContext) -> None:
+    def __init__(
+        self,
+        *,
+        backend: BackendClient,
+        auth: AuthContext,
+        context_entities: dict[str, Any] | None = None,
+    ) -> None:
         self._backend = backend
         self._auth = auth
+        self._context_entities = dict(context_entities or {})
         self._tools = self._build_tools()
 
     def definitions(self) -> list[SemanticTool]:
@@ -35,6 +43,14 @@ class SemanticToolCatalog:
     def get(self, name: str) -> SemanticTool | None:
         return self._tools.get(name)
 
+    def validate(self, name: str, payload: dict[str, Any]) -> None:
+        tool = self.get(name)
+        if tool is None:
+            raise RuntimeError(f'Unknown semantic tool: {name}')
+        issues = validate_payload(tool.input_schema, payload)
+        if issues:
+            raise ToolSchemaValidationError(issues)
+
     async def prepare(self, name: str, payload: dict[str, Any]) -> dict[str, Any]:
         tool = self.get(name)
         if tool is None:
@@ -51,7 +67,7 @@ class SemanticToolCatalog:
         return await tool.executor(prepared)
 
     def _build_tools(self) -> dict[str, SemanticTool]:
-        resolver = EntityResolver(self._backend, self._auth)
+        resolver = EntityResolver(self._backend, self._auth, context_entities=self._context_entities)
         return {
             **build_commerce_tools(self._backend, self._auth, resolver),
             **build_inventory_tools(self._backend, self._auth, resolver),

--- a/conversational-engine/src/conversational_engine/tools/catalog/commerce.py
+++ b/conversational-engine/src/conversational_engine/tools/catalog/commerce.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from conversational_engine.clients.backend import BackendClient
@@ -7,11 +8,67 @@ from conversational_engine.contracts.auth import AuthContext
 from conversational_engine.retrieval.navigation_targets import NAVIGATION_TARGETS
 from conversational_engine.tools.definitions import SemanticTool
 
-from .resolvers import EntityResolver
-from .utils import ToolPreparationError, object_schema, search_rows
+from .resolvers import EntityResolver, ResolutionError
+from .utils import ToolPreparationError, best_match, object_schema, search_rows
 
 PARTY_FIELDS = ('name', 'email', 'phone', 'address', 'status')
 LOCATION_FIELDS = ('name', 'code', 'type', 'address', 'status')
+
+_MARKDOWN_MAILTO_RE = re.compile(
+    r'^\[(?P<label>[^\]]+)\]\(\s*mailto:(?P<target>[^)]+)\s*\)$',
+    re.IGNORECASE,
+)
+
+
+def commerce_line_schema(*, price_field: str, price_aliases: tuple[str, ...]) -> dict[str, Any]:
+    properties: dict[str, Any] = {
+        'sizeId': {'type': ['string', 'null'], 'description': 'SKU size UUID when already known'},
+        'productName': {
+            'type': ['string', 'null'],
+            'description': 'Product name or style code used to resolve the variant when sizeId is not known',
+        },
+        'skuCode': {'type': ['string', 'null'], 'description': 'Optional SKU code used to narrow the variant lookup'},
+        'styleCode': {'type': ['string', 'null'], 'description': 'Optional product style code used to resolve the product'},
+        'sizeLabel': {'type': ['string', 'null'], 'description': 'Size label such as S, M, L, or 32'},
+        'colorName': {'type': ['string', 'null'], 'description': 'Optional colour used to resolve sizeId'},
+        'qty': {'type': ['integer', 'null'], 'description': 'Canonical quantity field expected by the backend'},
+        'quantity': {'type': ['integer', 'null'], 'description': 'Human-friendly quantity alias'},
+        price_field: {'type': ['integer', 'null'], 'description': f'Canonical {price_field} field expected by the backend'},
+    }
+    for alias in price_aliases:
+        properties[alias] = {'type': ['integer', 'null'], 'description': f'Alias for {price_field}'}
+    return object_schema(properties)
+
+
+def commerce_line_ref_schema() -> dict[str, Any]:
+    return object_schema(
+        {
+            'lineId': {'type': ['string', 'null'], 'description': 'Existing line UUID when known'},
+            'lineNumber': {'type': ['integer', 'null'], 'description': '1-based line number within the current order'},
+            'sizeId': {'type': ['string', 'null'], 'description': 'Existing sku_size UUID when known'},
+            'skuCode': {'type': ['string', 'null'], 'description': 'SKU code for an exact variant reference'},
+            'sizeLabel': {'type': ['string', 'null'], 'description': 'Size label paired with skuCode'},
+            'productName': {'type': ['string', 'null'], 'description': 'Optional product name for resolving a sizeId'},
+            'styleCode': {'type': ['string', 'null'], 'description': 'Optional style code for resolving a sizeId'},
+            'colorName': {'type': ['string', 'null'], 'description': 'Optional colour used to resolve a sizeId'},
+        }
+    )
+
+
+def commerce_line_op_schema(*, price_field: str, price_aliases: tuple[str, ...], patch_price_field: str) -> dict[str, Any]:
+    properties: dict[str, Any] = {
+        'op': {
+            'type': 'string',
+            'enum': ['add', 'replace', 'change_qty', patch_price_field, 'remove'],
+        },
+        'lineRef': commerce_line_ref_schema(),
+        'values': commerce_line_schema(price_field=price_field, price_aliases=price_aliases),
+        'qty': {'type': ['integer', 'null']},
+        price_field: {'type': ['integer', 'null']},
+    }
+    for alias in price_aliases:
+        properties[alias] = {'type': ['integer', 'null']}
+    return object_schema(properties, ['op'])
 
 
 def build_commerce_tools(
@@ -28,6 +85,13 @@ def build_commerce_tools(
                 continue
             if isinstance(value, str):
                 cleaned = value.strip()
+                if field == 'email':
+                    markdown_match = _MARKDOWN_MAILTO_RE.match(cleaned)
+                    if markdown_match:
+                        candidate = markdown_match.group('target').strip()
+                        if candidate:
+                            cleaned = candidate
+                    cleaned = cleaned.strip('<>')
                 if not cleaned:
                     continue
                 normalized[field] = cleaned
@@ -87,6 +151,238 @@ def build_commerce_tools(
                 return value.strip()
         return ''
 
+    def as_positive_int(value: Any, *, field_name: str) -> int:
+        try:
+            normalized = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ToolPreparationError(f'{field_name} must be a positive integer.', ['lines']) from exc
+        if normalized <= 0:
+            raise ToolPreparationError(f'{field_name} must be a positive integer.', ['lines'])
+        return normalized
+
+    def as_non_negative_int(value: Any, *, field_name: str) -> int:
+        try:
+            normalized = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ToolPreparationError(f'{field_name} must be a non-negative integer.', ['lines']) from exc
+        if normalized < 0:
+            raise ToolPreparationError(f'{field_name} must be a non-negative integer.', ['lines'])
+        return normalized
+
+    async def resolve_commerce_line(
+        raw_line: dict[str, Any],
+        *,
+        price_field: str,
+        price_aliases: tuple[str, ...],
+        allow_price_lookup: bool,
+    ) -> dict[str, Any]:
+        qty = raw_line.get('qty', raw_line.get('quantity'))
+        if qty is None:
+            raise ToolPreparationError('Each line needs a quantity.', ['lines'])
+
+        price_value = raw_line.get(price_field)
+        if price_value is None:
+            for alias in price_aliases:
+                candidate = raw_line.get(alias)
+                if candidate is not None:
+                    price_value = candidate
+                    break
+
+        size_id = str(raw_line.get('sizeId') or '').strip()
+        resolved_price_value = price_value
+        if not size_id or resolved_price_value is None:
+            try:
+                details = await resolver.sku_size_details(
+                    str(raw_line.get('productName') or raw_line.get('styleCode') or '').strip(),
+                    str(raw_line.get('sizeLabel') or '').strip(),
+                    str(raw_line.get('colorName') or '').strip() or None,
+                    sku_code=str(raw_line.get('skuCode') or '').strip() or None,
+                )
+            except ValueError as exc:
+                raise ToolPreparationError(str(exc), ['lines']) from exc
+            size_id = size_id or str(details['sizeId'])
+            if allow_price_lookup and resolved_price_value is None:
+                resolved_price_value = details.get(price_field)
+
+        if not size_id:
+            raise ToolPreparationError('Each line needs a sizeId or a product/size reference.', ['lines'])
+
+        if resolved_price_value is None:
+            raise ToolPreparationError(f'Each line needs {price_field}.', ['lines'])
+
+        return {
+            'sizeId': size_id,
+            'qty': as_positive_int(qty, field_name='Quantity'),
+            price_field: as_non_negative_int(resolved_price_value, field_name=price_field),
+        }
+
+    def product_rows(payload: object) -> list[dict[str, Any]]:
+        if isinstance(payload, dict):
+            items = payload.get('items')
+            if isinstance(items, list):
+                return [row for row in items if isinstance(row, dict)]
+        if isinstance(payload, list):
+            return [row for row in payload if isinstance(row, dict)]
+        return []
+
+    async def product_detail_for_reference(reference: str) -> dict[str, Any]:
+        query = reference.strip()
+        products = product_rows(await backend.search_products(token, tenant, q=query))
+        match = best_match(products, query, 'name', 'styleCode', 'style_code', 'skuCode', 'sku_code')
+        if not match:
+            raise ToolPreparationError(f'Product "{reference}" not found.', ['product'])
+        product_id = str(match.get('id') or '').strip()
+        if not product_id:
+            raise ToolPreparationError(f'Product "{reference}" is missing an id.', ['product'])
+        detail = await backend.get_product(token, tenant, product_id)
+        if not isinstance(detail, dict):
+            raise ToolPreparationError(f'Product "{reference}" could not be loaded.', ['product'])
+        return detail
+
+    async def resolve_reference(call, missing_fields: list[str]):
+        try:
+            return await call
+        except ResolutionError as exc:
+            raise ToolPreparationError(exc.result.message, missing_fields) from exc
+        except ValueError as exc:
+            raise ToolPreparationError(str(exc), missing_fields) from exc
+
+    async def resolve_line_ref(
+        raw_line_ref: dict[str, Any],
+        *,
+        existing_lines: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        line_id = str(raw_line_ref.get('lineId') or '').strip()
+        if line_id:
+            return {'lineId': line_id}
+
+        line_number = raw_line_ref.get('lineNumber')
+        if line_number is not None:
+            if not isinstance(existing_lines, list) or not existing_lines:
+                raise ToolPreparationError('lineNumber can only be used when the current order lines are available.', ['line_ref'])
+            try:
+                index = as_positive_int(line_number, field_name='Line number') - 1
+            except ValueError as exc:
+                raise ToolPreparationError(str(exc), ['line_ref']) from exc
+            if index < 0 or index >= len(existing_lines):
+                raise ToolPreparationError('lineNumber is outside the current order line range.', ['line_ref'])
+            selected_line = existing_lines[index]
+            selected_line_id = str(selected_line.get('id') or '').strip()
+            if selected_line_id:
+                return {'lineId': selected_line_id}
+            selected_size_id = str(selected_line.get('skuId') or '').strip()
+            if selected_size_id:
+                return {'sizeId': selected_size_id}
+            raise ToolPreparationError('The selected line is missing a stable identifier.', ['line_ref'])
+
+        size_id = str(raw_line_ref.get('sizeId') or '').strip()
+        if size_id:
+            return {'sizeId': size_id}
+
+        sku_code = str(raw_line_ref.get('skuCode') or '').strip()
+        size_label = str(raw_line_ref.get('sizeLabel') or '').strip()
+        if sku_code and size_label:
+            return {'skuCode': sku_code, 'sizeLabel': size_label}
+
+        if str(raw_line_ref.get('productName') or raw_line_ref.get('styleCode') or '').strip() and size_label:
+            return {'sizeId': await resolver.size_from_payload(raw_line_ref)}
+
+        raise ToolPreparationError(
+            'Each line change needs a line reference: lineId, sizeId, or skuCode + sizeLabel.',
+            ['line_ref'],
+        )
+
+    async def resolve_line_ops(
+        raw_line_ops: list[dict[str, Any]],
+        *,
+        price_field: str,
+        price_aliases: tuple[str, ...],
+        patch_price_field: str,
+        existing_lines: list[dict[str, Any]] | None = None,
+    ) -> list[dict[str, Any]]:
+        resolved_ops: list[dict[str, Any]] = []
+        for raw_line_op in raw_line_ops:
+            op = str(raw_line_op.get('op') or '').strip().lower()
+            if op not in {'add', 'replace', 'change_qty', patch_price_field, 'remove'}:
+                raise ToolPreparationError(
+                    f'Unsupported line operation "{op or "unknown"}".',
+                    ['line_ops'],
+                )
+            if op == 'add':
+                values = raw_line_op.get('values')
+                if not isinstance(values, dict):
+                    raise ToolPreparationError('Add operations need line values.', ['line_ops'])
+                resolved_ops.append(
+                    {
+                        'op': 'add',
+                        'values': await resolve_commerce_line(
+                            values,
+                            price_field=price_field,
+                            price_aliases=price_aliases,
+                            allow_price_lookup=True,
+                        ),
+                    }
+                )
+                continue
+
+            line_ref = raw_line_op.get('lineRef')
+            if not isinstance(line_ref, dict):
+                raise ToolPreparationError('Each line change needs a lineRef.', ['line_ops'])
+            resolved_line_ref = await resolve_line_ref(line_ref, existing_lines=existing_lines)
+
+            if op == 'replace':
+                values = raw_line_op.get('values')
+                if not isinstance(values, dict):
+                    raise ToolPreparationError('Replace operations need line values.', ['line_ops'])
+                resolved_ops.append(
+                    {
+                        'op': 'replace',
+                        'lineRef': resolved_line_ref,
+                        'values': await resolve_commerce_line(
+                            values,
+                            price_field=price_field,
+                            price_aliases=price_aliases,
+                            allow_price_lookup=True,
+                        ),
+                    }
+                )
+                continue
+
+            if op == 'change_qty':
+                qty = raw_line_op.get('qty', raw_line_op.get('quantity'))
+                if qty is None:
+                    raise ToolPreparationError('Quantity changes need qty.', ['line_ops'])
+                resolved_ops.append(
+                    {
+                        'op': 'change_qty',
+                        'lineRef': resolved_line_ref,
+                        'qty': as_positive_int(qty, field_name='Quantity'),
+                    }
+                )
+                continue
+
+            if op == patch_price_field:
+                price_value = raw_line_op.get(price_field)
+                if price_value is None:
+                    for alias in price_aliases:
+                        candidate = raw_line_op.get(alias)
+                        if candidate is not None:
+                            price_value = candidate
+                            break
+                if price_value is None:
+                    raise ToolPreparationError(f'{price_field} is required for {patch_price_field}.', ['line_ops'])
+                resolved_ops.append(
+                    {
+                        'op': patch_price_field,
+                        'lineRef': resolved_line_ref,
+                        price_field: as_non_negative_int(price_value, field_name=price_field),
+                    }
+                )
+                continue
+
+            resolved_ops.append({'op': 'remove', 'lineRef': resolved_line_ref})
+        return resolved_ops
+
     async def search_locations(payload: dict[str, Any]) -> dict[str, Any]:
         items = await backend.list_locations(token, tenant)
         rows = search_rows(items, str(payload.get('query') or ''), 'name', 'code')
@@ -127,7 +423,7 @@ def build_commerce_tools(
         )
         if not patch:
             raise ToolPreparationError('What location details should I change?', ['patch'])
-        return {'locationId': await resolver.location(location), 'patch': patch}
+        return {'locationId': await resolve_reference(resolver.location(location), ['location_id']), 'patch': patch}
 
     async def update_location(payload: dict[str, Any]) -> dict[str, Any]:
         return {
@@ -143,7 +439,7 @@ def build_commerce_tools(
         location = first_reference(payload, 'locationId', 'location', 'locationName', 'reference', 'id', 'code')
         if not location:
             raise ToolPreparationError('Which location should I delete?', ['location_id'])
-        return {'locationId': await resolver.location(location)}
+        return {'locationId': await resolve_reference(resolver.location(location), ['location_id'])}
 
     async def delete_location(payload: dict[str, Any]) -> dict[str, Any]:
         return {'result': await backend.delete_location(token, tenant, str(payload['locationId']))}
@@ -165,7 +461,10 @@ def build_commerce_tools(
         return normalized
 
     async def create_supplier(payload: dict[str, Any]) -> dict[str, Any]:
-        return {'result': await backend.create_supplier(token, tenant, payload)}
+        # Re-apply field cleaning as a defensive measure before hitting the backend.
+        # The preparer already does this, but the approval path may replay a stored payload.
+        clean = clean_party_fields(payload)
+        return {'result': await backend.create_supplier(token, tenant, clean)}
 
     async def prepare_update_supplier(payload: dict[str, Any]) -> dict[str, Any]:
         supplier = first_reference(payload, 'supplierId', 'supplier', 'supplierName', 'reference', 'id')
@@ -174,7 +473,7 @@ def build_commerce_tools(
         patch = extract_patch(payload, identifier_keys=('supplierId', 'supplier', 'supplierName', 'reference', 'id'))
         if not patch:
             raise ToolPreparationError('What supplier details should I change?', ['patch'])
-        return {'supplierId': await resolver.supplier(supplier), 'patch': patch}
+        return {'supplierId': await resolve_reference(resolver.supplier(supplier), ['supplier_id']), 'patch': patch}
 
     async def update_supplier(payload: dict[str, Any]) -> dict[str, Any]:
         return {
@@ -190,7 +489,7 @@ def build_commerce_tools(
         supplier = first_reference(payload, 'supplierId', 'supplier', 'supplierName', 'reference', 'id')
         if not supplier:
             raise ToolPreparationError('Which supplier should I delete?', ['supplier_id'])
-        return {'supplierId': await resolver.supplier(supplier)}
+        return {'supplierId': await resolve_reference(resolver.supplier(supplier), ['supplier_id'])}
 
     async def delete_supplier(payload: dict[str, Any]) -> dict[str, Any]:
         return {'result': await backend.delete_supplier(token, tenant, str(payload['supplierId']))}
@@ -202,7 +501,10 @@ def build_commerce_tools(
         return normalized
 
     async def create_customer(payload: dict[str, Any]) -> dict[str, Any]:
-        return {'result': await backend.create_customer(token, tenant, payload)}
+        # Re-apply field cleaning as a defensive measure before hitting the backend.
+        # The preparer already does this, but the approval path may replay a stored payload.
+        clean = clean_party_fields(payload)
+        return {'result': await backend.create_customer(token, tenant, clean)}
 
     async def prepare_update_customer(payload: dict[str, Any]) -> dict[str, Any]:
         customer = first_reference(
@@ -222,7 +524,7 @@ def build_commerce_tools(
         )
         if not patch:
             raise ToolPreparationError('What customer details should I change?', ['patch'])
-        return {'customerId': await resolver.customer(customer), 'patch': patch}
+        return {'customerId': await resolve_reference(resolver.customer(customer), ['customer_id']), 'patch': patch}
 
     async def update_customer(payload: dict[str, Any]) -> dict[str, Any]:
         return {
@@ -246,7 +548,7 @@ def build_commerce_tools(
         )
         if not customer:
             raise ToolPreparationError('Which customer should I delete?', ['customer_id'])
-        return {'customerId': await resolver.customer(customer)}
+        return {'customerId': await resolve_reference(resolver.customer(customer), ['customer_id'])}
 
     async def delete_customer(payload: dict[str, Any]) -> dict[str, Any]:
         return {'result': await backend.delete_customer(token, tenant, str(payload['customerId']))}
@@ -271,7 +573,7 @@ def build_commerce_tools(
         supplier = str(payload.get('supplierId') or '').strip()
         if not supplier:
             raise ToolPreparationError('Which supplier should this purchase order use?', ['supplier_id'])
-        resolved['supplierId'] = await resolver.supplier(supplier)
+        resolved['supplierId'] = await resolve_reference(resolver.supplier(supplier), ['supplier_id'])
 
         raw_lines = payload.get('lines')
         if not isinstance(raw_lines, list) or not raw_lines:
@@ -287,30 +589,13 @@ def build_commerce_tools(
                     'Reply with PO lines in the format `SKUCODE/SIZE xQTY @UNIT_COST`, separated by commas.',
                     ['lines'],
                 )
-
-            qty = raw_line.get('qty', raw_line.get('quantity'))
-            unit_cost = raw_line.get('unitCost', raw_line.get('cost'))
-            if qty is None or int(qty) <= 0 or unit_cost is None:
-                raise ToolPreparationError(
-                    'Each PO line needs an item, quantity, and unit cost.',
-                    ['lines'],
-                )
-
-            size_id = str(raw_line.get('sizeId') or '').strip()
-            if size_id:
-                resolved_size_id = size_id
-            else:
-                try:
-                    resolved_size_id = await resolver.size_from_payload(raw_line)
-                except ValueError as exc:
-                    raise ToolPreparationError(str(exc), ['lines']) from exc
-
             resolved_lines.append(
-                {
-                    'sizeId': resolved_size_id,
-                    'qty': int(qty),
-                    'unitCost': int(unit_cost),
-                }
+                await resolve_commerce_line(
+                    raw_line,
+                    price_field='unitCost',
+                    price_aliases=('cost', 'unit_price', 'price'),
+                    allow_price_lookup=True,
+                )
             )
 
         resolved['lines'] = resolved_lines
@@ -319,19 +604,106 @@ def build_commerce_tools(
     async def create_po(payload: dict[str, Any]) -> dict[str, Any]:
         return {'result': await backend.create_po(token, tenant, payload)}
 
+    async def prepare_get_po(payload: dict[str, Any]) -> dict[str, Any]:
+        po_ref = first_reference(payload, 'poId', 'purchaseOrderId', 'purchaseOrder', 'reference', 'id')
+        if not po_ref:
+            raise ToolPreparationError('Which purchase order should I inspect?', ['po_id'])
+        return {'poId': await resolve_reference(resolver.purchase_order(po_ref), ['po_id'])}
+
+    async def get_po(payload: dict[str, Any]) -> dict[str, Any]:
+        return {'result': await backend.get_po(token, tenant, str(payload['poId']))}
+
+    async def prepare_list_pos(payload: dict[str, Any]) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        status = payload.get('status')
+        if isinstance(status, str) and status.strip():
+            params['status'] = status.strip()
+        supplier = str(payload.get('supplierId') or payload.get('supplier') or payload.get('supplierName') or '').strip()
+        if supplier:
+            params['supplierId'] = await resolve_reference(resolver.supplier(supplier), ['supplier_id'])
+        return params
+
+    async def list_pos(payload: dict[str, Any]) -> dict[str, Any]:
+        return {'result': await backend.list_pos(token, tenant, params=payload or None)}
+
+    async def prepare_update_po(payload: dict[str, Any]) -> dict[str, Any]:
+        po_ref = first_reference(payload, 'poId', 'purchaseOrderId', 'purchaseOrder', 'reference', 'id')
+        if not po_ref:
+            raise ToolPreparationError('Which purchase order should I update?', ['po_id'])
+
+        resolved: dict[str, Any] = {'poId': await resolve_reference(resolver.purchase_order(po_ref), ['po_id'])}
+        header_patch: dict[str, Any] = {}
+        raw_header_patch = payload.get('headerPatch')
+        if isinstance(raw_header_patch, dict):
+            supplier = str(raw_header_patch.get('supplierId') or '').strip()
+            if supplier:
+                header_patch['supplierId'] = await resolve_reference(resolver.supplier(supplier), ['supplier_id'])
+            if 'expectedDate' in raw_header_patch:
+                header_patch['expectedDate'] = raw_header_patch.get('expectedDate')
+        supplier = str(payload.get('supplierId') or '').strip()
+        if supplier:
+            header_patch['supplierId'] = await resolve_reference(resolver.supplier(supplier), ['supplier_id'])
+        if 'expectedDate' in payload:
+            header_patch['expectedDate'] = payload.get('expectedDate')
+        if header_patch:
+            resolved['headerPatch'] = header_patch
+
+        raw_lines = payload.get('lines')
+        if isinstance(raw_lines, list) and raw_lines:
+            resolved['lines'] = [
+                await resolve_commerce_line(
+                    raw_line,
+                    price_field='unitCost',
+                    price_aliases=('cost', 'unit_price', 'price'),
+                    allow_price_lookup=True,
+                )
+                for raw_line in raw_lines
+                if isinstance(raw_line, dict)
+            ]
+            if len(resolved['lines']) != len(raw_lines):
+                raise ToolPreparationError('Each purchase order line must be an object.', ['lines'])
+
+        raw_line_ops = payload.get('lineOps')
+        if isinstance(raw_line_ops, list) and raw_line_ops:
+            if not all(isinstance(raw_line_op, dict) for raw_line_op in raw_line_ops):
+                raise ToolPreparationError('Each purchase order line change must be an object.', ['line_ops'])
+            po_detail = await backend.get_po(token, tenant, str(resolved['poId']))
+            detail_lines = po_detail.get('lines') if isinstance(po_detail, dict) else None
+            po_lines = [line for line in detail_lines if isinstance(line, dict)] if isinstance(detail_lines, list) else []
+            resolved['lineOps'] = await resolve_line_ops(
+                raw_line_ops,  # type: ignore[arg-type]
+                price_field='unitCost',
+                price_aliases=('cost', 'unit_price', 'price'),
+                patch_price_field='change_cost',
+                existing_lines=po_lines,
+            )
+
+        if not any(key in resolved for key in ('headerPatch', 'lines', 'lineOps')):
+            raise ToolPreparationError('What should I change on this purchase order?', ['patch'])
+        return resolved
+
+    async def update_po(payload: dict[str, Any]) -> dict[str, Any]:
+        po_id = str(payload['poId'])
+        request_payload = {
+            key: payload[key]
+            for key in ('headerPatch', 'lines', 'lineOps')
+            if key in payload
+        }
+        return {'result': await backend.update_po(token, tenant, po_id, request_payload)}
+
     async def prepare_receive_po(payload: dict[str, Any]) -> dict[str, Any]:
         po_ref = first_reference(payload, 'poId', 'purchaseOrderId', 'purchaseOrder', 'reference', 'id')
         if not po_ref:
             raise ToolPreparationError('Which purchase order should I receive?', ['po_id'])
 
         resolved = dict(payload)
-        po_id = await resolver.purchase_order(po_ref)
+        po_id = await resolve_reference(resolver.purchase_order(po_ref), ['po_id'])
         resolved['poId'] = po_id
 
         location = first_reference(payload, 'locationId', 'location', 'locationCode')
         if not location:
             raise ToolPreparationError('Which location should receive this purchase order?', ['location_id'])
-        resolved['locationId'] = await resolver.location(location)
+        resolved['locationId'] = await resolve_reference(resolver.location(location), ['location_id'])
 
         po_detail = await backend.get_po(token, tenant, po_id)
         detail_lines = po_detail.get('lines') if isinstance(po_detail, dict) else None
@@ -377,7 +749,7 @@ def build_commerce_tools(
             if not isinstance(raw_line, dict):
                 raise ToolPreparationError('Each purchase order receipt line must be an object.', ['lines'])
             qty = raw_line.get('qty', raw_line.get('quantity'))
-            if qty is None or int(qty) <= 0:
+            if qty is None:
                 raise ToolPreparationError('Each purchase order receipt line needs a quantity.', ['lines'])
 
             size_id = str(raw_line.get('sizeId') or '').strip()
@@ -395,7 +767,13 @@ def build_commerce_tools(
                     ['lines'],
                 )
 
-            resolved_lines.append({'sizeId': size_id, 'qty': int(qty), 'unitCost': int(unit_cost)})
+            resolved_lines.append(
+                {
+                    'sizeId': size_id,
+                    'qty': as_positive_int(qty, field_name='Quantity'),
+                    'unitCost': as_non_negative_int(unit_cost, field_name='unitCost'),
+                }
+            )
 
         resolved['lines'] = resolved_lines
         resolved['confirm'] = True
@@ -414,17 +792,26 @@ def build_commerce_tools(
         po_ref = first_reference(payload, 'poId', 'purchaseOrderId', 'purchaseOrder', 'reference', 'id')
         if not po_ref:
             raise ToolPreparationError('Which purchase order should I close?', ['po_id'])
-        return {'poId': await resolver.purchase_order(po_ref)}
+        return {'poId': await resolve_reference(resolver.purchase_order(po_ref), ['po_id']), 'confirm': True}
 
     async def close_po(payload: dict[str, Any]) -> dict[str, Any]:
         return {'result': await backend.close_po(token, tenant, str(payload['poId']))}
+
+    async def prepare_cancel_po(payload: dict[str, Any]) -> dict[str, Any]:
+        po_ref = first_reference(payload, 'poId', 'purchaseOrderId', 'purchaseOrder', 'reference', 'id')
+        if not po_ref:
+            raise ToolPreparationError('Which purchase order should I cancel?', ['po_id'])
+        return {'poId': await resolve_reference(resolver.purchase_order(po_ref), ['po_id']), 'confirm': True}
+
+    async def cancel_po(payload: dict[str, Any]) -> dict[str, Any]:
+        return {'result': await backend.cancel_po(token, tenant, str(payload['poId']))}
 
     async def prepare_create_invoice(payload: dict[str, Any]) -> dict[str, Any]:
         resolved = dict(payload)
         customer = str(payload.get('customerId') or '').strip()
         if not customer:
             raise ToolPreparationError('Which customer should this sales order use?', ['customer_id'])
-        resolved['customerId'] = await resolver.customer(customer)
+        resolved['customerId'] = await resolve_reference(resolver.customer(customer), ['customer_id'])
 
         raw_lines = payload.get('lines')
         if not isinstance(raw_lines, list) or not raw_lines:
@@ -440,33 +827,13 @@ def build_commerce_tools(
                     'Reply with sales order lines that include item, size, and quantity.',
                     ['lines'],
                 )
-
-            line_size_id = str(raw_line.get('sizeId') or '').strip()
-            qty = raw_line.get('qty', raw_line.get('quantity'))
-            unit_price = raw_line.get('unitPrice')
-
-            if qty is None or int(qty) <= 0:
-                raise ToolPreparationError('Each sales order line needs an item and quantity.', ['lines'])
-
-            if not line_size_id or unit_price is None:
-                try:
-                    details = await resolver.sku_size_details(
-                        str(raw_line.get('productName') or '').strip(),
-                        str(raw_line.get('sizeLabel') or '').strip(),
-                        str(raw_line.get('colorName') or '').strip() or None,
-                    )
-                except ValueError as exc:
-                    raise ToolPreparationError(str(exc), ['lines']) from exc
-                line_size_id = str(details['sizeId'])
-                if unit_price is None:
-                    unit_price = details['unitPrice']
-
             resolved_lines.append(
-                {
-                    'sizeId': line_size_id,
-                    'qty': int(qty),
-                    'unitPrice': int(unit_price),
-                }
+                await resolve_commerce_line(
+                    raw_line,
+                    price_field='unitPrice',
+                    price_aliases=('unit_price', 'price'),
+                    allow_price_lookup=True,
+                )
             )
 
         resolved['lines'] = resolved_lines
@@ -474,6 +841,89 @@ def build_commerce_tools(
 
     async def create_invoice(payload: dict[str, Any]) -> dict[str, Any]:
         return {'result': await backend.create_invoice(token, tenant, payload)}
+
+    async def prepare_get_invoice(payload: dict[str, Any]) -> dict[str, Any]:
+        invoice_ref = first_reference(payload, 'invoiceId', 'salesOrderId', 'salesOrder', 'reference', 'id')
+        if not invoice_ref:
+            raise ToolPreparationError('Which sales order should I inspect?', ['sales_order_id'])
+        return {'invoiceId': await resolve_reference(resolver.invoice(invoice_ref), ['sales_order_id'])}
+
+    async def get_invoice(payload: dict[str, Any]) -> dict[str, Any]:
+        return {'result': await backend.get_invoice(token, tenant, str(payload['invoiceId']))}
+
+    async def prepare_list_invoices(payload: dict[str, Any]) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        status = payload.get('status')
+        if isinstance(status, str) and status.strip():
+            params['status'] = status.strip()
+        customer = str(payload.get('customerId') or payload.get('customer') or payload.get('customerName') or '').strip()
+        if customer:
+            params['customerId'] = await resolve_reference(resolver.customer(customer), ['customer_id'])
+        return params
+
+    async def list_invoices(payload: dict[str, Any]) -> dict[str, Any]:
+        return {'result': await backend.list_invoices(token, tenant, params=payload or None)}
+
+    async def prepare_update_invoice(payload: dict[str, Any]) -> dict[str, Any]:
+        invoice_ref = first_reference(payload, 'invoiceId', 'salesOrderId', 'salesOrder', 'reference', 'id')
+        if not invoice_ref:
+            raise ToolPreparationError('Which sales order should I update?', ['sales_order_id'])
+
+        resolved: dict[str, Any] = {'invoiceId': await resolve_reference(resolver.invoice(invoice_ref), ['sales_order_id'])}
+        header_patch: dict[str, Any] = {}
+        raw_header_patch = payload.get('headerPatch')
+        if isinstance(raw_header_patch, dict):
+            customer = str(raw_header_patch.get('customerId') or '').strip()
+            if customer:
+                header_patch['customerId'] = await resolve_reference(resolver.customer(customer), ['customer_id'])
+        customer = str(payload.get('customerId') or '').strip()
+        if customer:
+            header_patch['customerId'] = await resolve_reference(resolver.customer(customer), ['customer_id'])
+        if header_patch:
+            resolved['headerPatch'] = header_patch
+
+        raw_lines = payload.get('lines')
+        if isinstance(raw_lines, list) and raw_lines:
+            resolved['lines'] = [
+                await resolve_commerce_line(
+                    raw_line,
+                    price_field='unitPrice',
+                    price_aliases=('unit_price', 'price'),
+                    allow_price_lookup=True,
+                )
+                for raw_line in raw_lines
+                if isinstance(raw_line, dict)
+            ]
+            if len(resolved['lines']) != len(raw_lines):
+                raise ToolPreparationError('Each sales order line must be an object.', ['lines'])
+
+        raw_line_ops = payload.get('lineOps')
+        if isinstance(raw_line_ops, list) and raw_line_ops:
+            if not all(isinstance(raw_line_op, dict) for raw_line_op in raw_line_ops):
+                raise ToolPreparationError('Each sales order line change must be an object.', ['line_ops'])
+            invoice_detail = await backend.get_invoice(token, tenant, str(resolved['invoiceId']))
+            detail_lines = invoice_detail.get('lines') if isinstance(invoice_detail, dict) else None
+            invoice_lines = [line for line in detail_lines if isinstance(line, dict)] if isinstance(detail_lines, list) else []
+            resolved['lineOps'] = await resolve_line_ops(
+                raw_line_ops,  # type: ignore[arg-type]
+                price_field='unitPrice',
+                price_aliases=('unit_price', 'price'),
+                patch_price_field='change_price',
+                existing_lines=invoice_lines,
+            )
+
+        if not any(key in resolved for key in ('headerPatch', 'lines', 'lineOps')):
+            raise ToolPreparationError('What should I change on this sales order?', ['patch'])
+        return resolved
+
+    async def update_invoice(payload: dict[str, Any]) -> dict[str, Any]:
+        invoice_id = str(payload['invoiceId'])
+        request_payload = {
+            key: payload[key]
+            for key in ('headerPatch', 'lines', 'lineOps')
+            if key in payload
+        }
+        return {'result': await backend.update_invoice(token, tenant, invoice_id, request_payload)}
 
     async def prepare_dispatch_invoice(payload: dict[str, Any]) -> dict[str, Any]:
         invoice_ref = first_reference(payload, 'invoiceId', 'salesOrderId', 'salesOrder', 'reference', 'id')
@@ -483,8 +933,8 @@ def build_commerce_tools(
         if not location:
             raise ToolPreparationError('Which location should dispatch this sales order?', ['location_id'])
         return {
-            'invoiceId': await resolver.invoice(invoice_ref),
-            'locationId': await resolver.location(location),
+            'invoiceId': await resolve_reference(resolver.invoice(invoice_ref), ['sales_order_id']),
+            'locationId': await resolve_reference(resolver.location(location), ['location_id']),
             'confirm': True,
         }
 
@@ -500,10 +950,45 @@ def build_commerce_tools(
         invoice_ref = first_reference(payload, 'invoiceId', 'salesOrderId', 'salesOrder', 'reference', 'id')
         if not invoice_ref:
             raise ToolPreparationError('Which sales order should I cancel?', ['sales_order_id'])
-        return {'invoiceId': await resolver.invoice(invoice_ref)}
+        return {'invoiceId': await resolve_reference(resolver.invoice(invoice_ref), ['sales_order_id']), 'confirm': True}
 
     async def cancel_invoice(payload: dict[str, Any]) -> dict[str, Any]:
         return {'result': await backend.cancel_invoice(token, tenant, str(payload['invoiceId']))}
+
+    async def prepare_get_product_variants(payload: dict[str, Any]) -> dict[str, Any]:
+        reference = str(payload.get('product') or payload.get('productName') or payload.get('styleCode') or '').strip()
+        if not reference:
+            raise ToolPreparationError('Which product should I inspect?', ['product'])
+        detail = await product_detail_for_reference(reference)
+        return {'reference': reference, 'detail': detail}
+
+    async def get_product_variants(payload: dict[str, Any]) -> dict[str, Any]:
+        detail = payload.get('detail')
+        if not isinstance(detail, dict):
+            raise ToolPreparationError('Product detail is missing.', ['product'])
+        skus = detail.get('skus')
+        sizes = detail.get('sizes')
+        if not isinstance(skus, list) or not isinstance(sizes, list):
+            raise ToolPreparationError('Product variants are missing.', ['product'])
+        color_by_sku_id = {
+            str(sku.get('id') or ''): str(sku.get('color_name') or '').strip()
+            for sku in skus
+            if isinstance(sku, dict)
+        }
+        rows = []
+        for size in sizes:
+            if not isinstance(size, dict):
+                continue
+            sku_id = str(size.get('sku_id') or '').strip()
+            rows.append(
+                {
+                    'sizeId': str(size.get('id') or ''),
+                    'skuId': sku_id,
+                    'colorName': color_by_sku_id.get(sku_id, ''),
+                    'sizeLabel': str(size.get('size_label') or ''),
+                }
+            )
+        return {'rows': rows}
 
     return {
         'master.search_locations': SemanticTool(
@@ -707,7 +1192,7 @@ def build_commerce_tools(
                 {
                     'supplierId': {'type': 'string', 'description': 'Supplier name or UUID'},
                     'expectedDate': {'type': ['string', 'null']},
-                    'lines': {'type': 'array', 'items': {'type': 'object'}},
+                    'lines': {'type': 'array', 'items': commerce_line_schema(price_field='unitCost', price_aliases=('cost', 'unit_price', 'price')), 'minItems': 1},
                 },
                 ['supplierId', 'lines'],
             ),
@@ -717,6 +1202,74 @@ def build_commerce_tools(
             executor=create_po,
             preparer=prepare_create_po,
         ),
+        'purchasing.get_po': SemanticTool(
+            name='purchasing.get_po',
+            description='Fetch a purchase order by number or UUID.',
+            input_schema=object_schema(
+                {'poId': {'type': 'string', 'description': 'Purchase order number or UUID'}},
+                ['poId'],
+            ),
+            risk_level='low',
+            side_effect=False,
+            output_mode='table',
+            executor=get_po,
+            preparer=prepare_get_po,
+        ),
+        'purchasing.list_pos': SemanticTool(
+            name='purchasing.list_pos',
+            description='List purchase orders, optionally filtered by status or supplier.',
+            input_schema=object_schema(
+                {
+                    'status': {'type': ['string', 'null']},
+                    'supplierId': {'type': ['string', 'null'], 'description': 'Supplier UUID or natural reference'},
+                    'supplier': {'type': ['string', 'null']},
+                    'supplierName': {'type': ['string', 'null']},
+                }
+            ),
+            risk_level='low',
+            side_effect=False,
+            output_mode='table',
+            executor=list_pos,
+            preparer=prepare_list_pos,
+        ),
+        'purchasing.update_po': SemanticTool(
+            name='purchasing.update_po',
+            description='Update an existing purchase order by number or UUID.',
+            input_schema=object_schema(
+                {
+                    'poId': {'type': 'string', 'description': 'Purchase order number or UUID'},
+                    'supplierId': {'type': ['string', 'null'], 'description': 'Supplier UUID or natural reference'},
+                    'expectedDate': {'type': ['string', 'null']},
+                    'headerPatch': {
+                        'type': 'object',
+                        'properties': {
+                            'supplierId': {'type': ['string', 'null']},
+                            'expectedDate': {'type': ['string', 'null']},
+                        },
+                    },
+                    'lines': {
+                        'type': ['array', 'null'],
+                        'items': commerce_line_schema(price_field='unitCost', price_aliases=('cost', 'unit_price', 'price')),
+                        'minItems': 1,
+                    },
+                    'lineOps': {
+                        'type': ['array', 'null'],
+                        'items': commerce_line_op_schema(
+                            price_field='unitCost',
+                            price_aliases=('cost', 'unit_price', 'price'),
+                            patch_price_field='change_cost',
+                        ),
+                        'minItems': 1,
+                    },
+                },
+                ['poId'],
+            ),
+            risk_level='high',
+            side_effect=True,
+            output_mode='mutation',
+            executor=update_po,
+            preparer=prepare_update_po,
+        ),
         'purchasing.receive_po': SemanticTool(
             name='purchasing.receive_po',
             description='Receive stock against an existing purchase order into a location.',
@@ -724,7 +1277,11 @@ def build_commerce_tools(
                 {
                     'poId': {'type': 'string', 'description': 'Purchase order number or UUID'},
                     'locationId': {'type': 'string', 'description': 'Location name, code, or UUID'},
-                    'lines': {'type': ['array', 'null'], 'items': {'type': 'object'}},
+                    'lines': {
+                        'type': ['array', 'null'],
+                        'items': commerce_line_schema(price_field='unitCost', price_aliases=('cost', 'unit_price', 'price')),
+                        'minItems': 1,
+                    },
                 },
                 ['poId', 'locationId'],
             ),
@@ -747,13 +1304,26 @@ def build_commerce_tools(
             executor=close_po,
             preparer=prepare_close_po,
         ),
+        'purchasing.cancel_po': SemanticTool(
+            name='purchasing.cancel_po',
+            description='Cancel an existing purchase order by number or UUID.',
+            input_schema=object_schema(
+                {'poId': {'type': 'string', 'description': 'Purchase order number or UUID'}},
+                ['poId'],
+            ),
+            risk_level='high',
+            side_effect=True,
+            output_mode='mutation',
+            executor=cancel_po,
+            preparer=prepare_cancel_po,
+        ),
         'sales.create_invoice': SemanticTool(
             name='sales.create_invoice',
             description='Create a sales order or invoice. Customer accepts a name, email, or UUID.',
             input_schema=object_schema(
                 {
                     'customerId': {'type': 'string', 'description': 'Customer name, email, or UUID'},
-                    'lines': {'type': 'array', 'items': {'type': 'object'}},
+                    'lines': {'type': 'array', 'items': commerce_line_schema(price_field='unitPrice', price_aliases=('unit_price', 'price')), 'minItems': 1},
                 },
                 ['customerId', 'lines'],
             ),
@@ -762,6 +1332,72 @@ def build_commerce_tools(
             output_mode='mutation',
             executor=create_invoice,
             preparer=prepare_create_invoice,
+        ),
+        'sales.get_invoice': SemanticTool(
+            name='sales.get_invoice',
+            description='Fetch a sales order by number or UUID.',
+            input_schema=object_schema(
+                {'invoiceId': {'type': 'string', 'description': 'Sales order number or UUID'}},
+                ['invoiceId'],
+            ),
+            risk_level='low',
+            side_effect=False,
+            output_mode='table',
+            executor=get_invoice,
+            preparer=prepare_get_invoice,
+        ),
+        'sales.list_invoices': SemanticTool(
+            name='sales.list_invoices',
+            description='List sales orders, optionally filtered by status or customer.',
+            input_schema=object_schema(
+                {
+                    'status': {'type': ['string', 'null']},
+                    'customerId': {'type': ['string', 'null'], 'description': 'Customer UUID or natural reference'},
+                    'customer': {'type': ['string', 'null']},
+                    'customerName': {'type': ['string', 'null']},
+                }
+            ),
+            risk_level='low',
+            side_effect=False,
+            output_mode='table',
+            executor=list_invoices,
+            preparer=prepare_list_invoices,
+        ),
+        'sales.update_invoice': SemanticTool(
+            name='sales.update_invoice',
+            description='Update an existing sales order by number or UUID.',
+            input_schema=object_schema(
+                {
+                    'invoiceId': {'type': 'string', 'description': 'Sales order number or UUID'},
+                    'customerId': {'type': ['string', 'null'], 'description': 'Customer UUID or natural reference'},
+                    'headerPatch': {
+                        'type': 'object',
+                        'properties': {
+                            'customerId': {'type': ['string', 'null']},
+                        },
+                    },
+                    'lines': {
+                        'type': ['array', 'null'],
+                        'items': commerce_line_schema(price_field='unitPrice', price_aliases=('unit_price', 'price')),
+                        'minItems': 1,
+                    },
+                    'lineOps': {
+                        'type': ['array', 'null'],
+                        'items': commerce_line_op_schema(
+                            price_field='unitPrice',
+                            price_aliases=('unit_price', 'price'),
+                            patch_price_field='change_price',
+                        ),
+                        'minItems': 1,
+                    },
+                },
+                ['invoiceId'],
+            ),
+            risk_level='high',
+            side_effect=True,
+            output_mode='mutation',
+            executor=update_invoice,
+            preparer=prepare_update_invoice,
         ),
         'sales.dispatch_invoice': SemanticTool(
             name='sales.dispatch_invoice',
@@ -791,5 +1427,21 @@ def build_commerce_tools(
             output_mode='mutation',
             executor=cancel_invoice,
             preparer=prepare_cancel_invoice,
+        ),
+        'products.get_product_variants': SemanticTool(
+            name='products.get_product_variants',
+            description='List the available colour and size variants for a product.',
+            input_schema=object_schema(
+                {
+                    'product': {'type': ['string', 'null']},
+                    'productName': {'type': ['string', 'null']},
+                    'styleCode': {'type': ['string', 'null']},
+                },
+            ),
+            risk_level='low',
+            side_effect=False,
+            output_mode='table',
+            executor=get_product_variants,
+            preparer=prepare_get_product_variants,
         ),
     }

--- a/conversational-engine/src/conversational_engine/tools/catalog/products.py
+++ b/conversational-engine/src/conversational_engine/tools/catalog/products.py
@@ -10,6 +10,37 @@ from .normalizers import normalize_product_create_payload
 from .resolvers import EntityResolver
 from .utils import ToolPreparationError, is_uuid, object_schema
 
+PRODUCT_SIZE_SCHEMA = object_schema(
+    {
+        'sizeLabel': {'type': ['string', 'null']},
+        'size': {'type': ['string', 'null']},
+        'barcode': {'type': ['string', 'null']},
+        'locationId': {'type': ['string', 'null']},
+        'quantity': {'type': ['integer', 'null']},
+        'stockByLocation': {
+            'type': ['array', 'null'],
+            'items': object_schema(
+                {
+                    'locationId': {'type': 'string'},
+                    'quantity': {'type': 'integer'},
+                }
+            ),
+        },
+    }
+)
+PRODUCT_VARIANT_SCHEMA = object_schema(
+    {
+        'colorName': {'type': ['string', 'null']},
+        'color': {'type': ['string', 'null']},
+        'skuCode': {'type': ['string', 'null']},
+        'sizes': {'type': ['array', 'null'], 'items': PRODUCT_SIZE_SCHEMA},
+        'sizeLabel': {'type': ['string', 'null']},
+        'size': {'type': ['string', 'null']},
+        'locationId': {'type': ['string', 'null']},
+        'quantity': {'type': ['integer', 'null']},
+    }
+)
+
 
 def build_product_tools(
     backend: BackendClient, auth: AuthContext, resolver: EntityResolver
@@ -114,7 +145,7 @@ def build_product_tools(
                     'categoryId': {'type': ['string', 'null'], 'description': 'Category name or UUID'},
                     'basePrice': {'type': 'integer'},
                     'pickupEnabled': {'type': ['boolean', 'null']},
-                    'variants': {'type': 'array', 'items': {'type': 'object'}},
+                    'variants': {'type': 'array', 'items': PRODUCT_VARIANT_SCHEMA},
                 },
                 ['styleCode', 'name', 'basePrice', 'variants'],
             ),

--- a/conversational-engine/src/conversational_engine/tools/catalog/resolvers.py
+++ b/conversational-engine/src/conversational_engine/tools/catalog/resolvers.py
@@ -1,19 +1,49 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+import re
 from typing import Any
 
 from conversational_engine.clients.backend import BackendClient
 from conversational_engine.contracts.auth import AuthContext
 
-from .utils import best_match, is_uuid
+from .utils import is_uuid
+
+
+@dataclass(frozen=True, slots=True)
+class ResolutionCandidate:
+    id: str
+    label: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolutionResult:
+    status: str
+    value: str | None = None
+    message: str = ''
+    candidates: tuple[ResolutionCandidate, ...] = ()
+
+
+class ResolutionError(ValueError):
+    def __init__(self, result: ResolutionResult) -> None:
+        super().__init__(result.message)
+        self.result = result
 
 
 class EntityResolver:
     """Resolves human-readable names (locations, suppliers, products…) to backend UUIDs."""
 
-    def __init__(self, backend: BackendClient, auth: AuthContext) -> None:
+    def __init__(
+        self,
+        backend: BackendClient,
+        auth: AuthContext,
+        *,
+        context_entities: dict[str, Any] | None = None,
+    ) -> None:
         self._backend = backend
         self._auth = auth
+        self._cache: dict[str, object] = {}
+        self._context_entities = dict(context_entities or {})
 
     @property
     def _token(self) -> str:
@@ -26,66 +56,170 @@ class EntityResolver:
     async def location(self, name_or_id: str) -> str:
         if is_uuid(name_or_id):
             return name_or_id
-        items = await self._backend.list_locations(self._token, self._tenant)
-        match = best_match(items, name_or_id, 'name', 'code')
-        if match:
-            return str(match['id'])
-        available = ', '.join(str(location.get('name') or location.get('code')) for location in items[:10])
-        raise ValueError(f'Location "{name_or_id}" not found. Available: {available}')
+        items = await self._cached_rows('locations', lambda: self._backend.list_locations(self._token, self._tenant))
+        return self._require_resolved(
+            self._resolve_named_entity(
+                items,
+                name_or_id,
+                match_fields=('id', 'name', 'code'),
+                label_fields=('name', 'code'),
+                singular='location',
+                plural='locations',
+            )
+        )
 
     async def supplier(self, name_or_id: str) -> str:
         if is_uuid(name_or_id):
             return name_or_id
-        items = await self._backend.list_suppliers(self._token, self._tenant)
-        match = best_match(items, name_or_id, 'name', 'code')
-        if match:
-            return str(match['id'])
-        available = ', '.join(str(s.get('name')) for s in items[:10])
-        raise ValueError(f'Supplier "{name_or_id}" not found. Available: {available}')
+        relative = self._relative_context_value(
+            name_or_id,
+            terms=('same supplier', 'this supplier', 'that supplier', 'supplier we just created'),
+            value_keys=('supplierId',),
+        )
+        if relative is not None:
+            return self._require_resolved(relative)
+        items = await self._cached_rows('suppliers', lambda: self._backend.list_suppliers(self._token, self._tenant))
+        return self._require_resolved(
+            self._resolve_named_entity(
+                items,
+                name_or_id,
+                match_fields=('id', 'name', 'code'),
+                label_fields=('name', 'code'),
+                singular='supplier',
+                plural='suppliers',
+            )
+        )
 
     async def customer(self, name_or_id: str) -> str:
         if is_uuid(name_or_id):
             return name_or_id
-        items = await self._backend.list_customers(self._token, self._tenant)
-        match = best_match(items, name_or_id, 'name', 'email', 'code')
-        if match:
-            return str(match['id'])
-        available = ', '.join(str(c.get('name')) for c in items[:10])
-        raise ValueError(f'Customer "{name_or_id}" not found. Available: {available}')
+        relative = self._relative_context_value(
+            name_or_id,
+            terms=('same customer', 'this customer', 'that customer', 'customer we just created'),
+            value_keys=('customerId',),
+        )
+        if relative is not None:
+            return self._require_resolved(relative)
+        items = await self._cached_rows('customers', lambda: self._backend.list_customers(self._token, self._tenant))
+        return self._require_resolved(
+            self._resolve_named_entity(
+                items,
+                name_or_id,
+                match_fields=('id', 'name', 'email', 'code'),
+                label_fields=('name', 'email', 'code'),
+                singular='customer',
+                plural='customers',
+            )
+        )
 
     async def category(self, name_or_id: str) -> str:
         if is_uuid(name_or_id):
             return name_or_id
-        items = await self._backend.list_categories(self._token, self._tenant)
-        match = best_match(items, name_or_id, 'name')
-        if match:
-            return str(match['id'])
-        available = ', '.join(str(c.get('name')) for c in items[:10])
-        raise ValueError(f'Category "{name_or_id}" not found. Available: {available}')
+        items = await self._cached_rows('categories', lambda: self._backend.list_categories(self._token, self._tenant))
+        return self._require_resolved(
+            self._resolve_named_entity(
+                items,
+                name_or_id,
+                match_fields=('id', 'name'),
+                label_fields=('name',),
+                singular='category',
+                plural='categories',
+            )
+        )
 
     async def purchase_order(self, number_or_id: str) -> str:
         if is_uuid(number_or_id):
             return number_or_id
-        payload = await self._backend.list_pos(self._token, self._tenant)
+        payload = await self._cached_value('purchase_orders', lambda: self._backend.list_pos(self._token, self._tenant))
         items = payload.get('items') if isinstance(payload, dict) else None
         rows = items if isinstance(items, list) else []
-        match = best_match(rows, number_or_id, 'number', 'id', 'supplierName', 'supplier_name')
-        if match:
-            return str(match['id'])
-        available = ', '.join(str(row.get('number') or row.get('id')) for row in rows[:10])
-        raise ValueError(f'Purchase order "{number_or_id}" not found. Available: {available or "none"}')
+        latest_for_party = self._latest_reference_for_party(
+            number_or_id,
+            rows=rows,
+            pattern=re.compile(
+                r'^(?:my\s+last|last|latest)\s+(?:purchase order|po)\s+for\s+(.+)$',
+                re.IGNORECASE,
+            ),
+            scope_fields=('supplierName', 'supplier_name'),
+            label_fields=('number', 'supplierName', 'supplier_name'),
+            singular='purchase order',
+            party_label='supplier',
+        )
+        if latest_for_party is not None:
+            return self._require_resolved(latest_for_party)
+        relative = self._relative_context_value(
+            number_or_id,
+            terms=('this purchase order', 'that purchase order', 'this po', 'that po'),
+            value_keys=('poId',),
+        )
+        if relative is not None:
+            return self._require_resolved(relative)
+        latest = self._latest_list_reference(
+            number_or_id,
+            terms=('last purchase order', 'my last purchase order', 'last po', 'my last po', 'latest po'),
+            rows=rows,
+            label_fields=('number', 'supplierName', 'supplier_name'),
+            singular='purchase order',
+        )
+        if latest is not None:
+            return self._require_resolved(latest)
+        return self._require_resolved(
+            self._resolve_named_entity(
+                rows,
+                number_or_id,
+                match_fields=('number', 'id', 'supplierName', 'supplier_name'),
+                label_fields=('number', 'supplierName', 'supplier_name'),
+                singular='purchase order',
+                plural='purchase orders',
+            )
+        )
 
     async def invoice(self, number_or_id: str) -> str:
         if is_uuid(number_or_id):
             return number_or_id
-        payload = await self._backend.list_invoices(self._token, self._tenant)
+        payload = await self._cached_value('invoices', lambda: self._backend.list_invoices(self._token, self._tenant))
         items = payload.get('items') if isinstance(payload, dict) else None
         rows = items if isinstance(items, list) else []
-        match = best_match(rows, number_or_id, 'number', 'id', 'customerName', 'customer_name')
-        if match:
-            return str(match['id'])
-        available = ', '.join(str(row.get('number') or row.get('id')) for row in rows[:10])
-        raise ValueError(f'Sales order "{number_or_id}" not found. Available: {available or "none"}')
+        latest_for_party = self._latest_reference_for_party(
+            number_or_id,
+            rows=rows,
+            pattern=re.compile(
+                r'^(?:my\s+last|last|latest)\s+(?:sales order|invoice|so)\s+for\s+(.+)$',
+                re.IGNORECASE,
+            ),
+            scope_fields=('customerName', 'customer_name'),
+            label_fields=('number', 'customerName', 'customer_name'),
+            singular='sales order',
+            party_label='customer',
+        )
+        if latest_for_party is not None:
+            return self._require_resolved(latest_for_party)
+        relative = self._relative_context_value(
+            number_or_id,
+            terms=('this sales order', 'that sales order', 'this invoice', 'that invoice', 'this so', 'that so'),
+            value_keys=('invoiceId',),
+        )
+        if relative is not None:
+            return self._require_resolved(relative)
+        latest = self._latest_list_reference(
+            number_or_id,
+            terms=('last sales order', 'my last sales order', 'last invoice', 'my last invoice', 'latest sales order'),
+            rows=rows,
+            label_fields=('number', 'customerName', 'customer_name'),
+            singular='sales order',
+        )
+        if latest is not None:
+            return self._require_resolved(latest)
+        return self._require_resolved(
+            self._resolve_named_entity(
+                rows,
+                number_or_id,
+                match_fields=('number', 'id', 'customerName', 'customer_name'),
+                label_fields=('number', 'customerName', 'customer_name'),
+                singular='sales order',
+                plural='sales orders',
+            )
+        )
 
     async def sku_size(
         self,
@@ -94,7 +228,7 @@ class EntityResolver:
         color_name: str | None = None,
     ) -> str:
         """Resolve product name + size label (+ optional colour) to a sku_size UUID."""
-        products = await self._backend.search_products(self._token, self._tenant, q=product_name)
+        products = self._product_rows(await self._backend.search_products(self._token, self._tenant, q=product_name))
         if not products:
             raise ValueError(f'Product "{product_name}" not found.')
 
@@ -133,37 +267,45 @@ class EntityResolver:
         product_name: str,
         size_label: str,
         color_name: str | None = None,
+        *,
+        sku_code: str | None = None,
     ) -> dict[str, int | str]:
         """Resolve a sales-order line to a sku_size UUID and effective unit price."""
-        products = await self._backend.search_products(self._token, self._tenant, q=product_name)
-        if not products:
-            raise ValueError(f'Product "{product_name}" not found.')
-
-        full = await self._backend.get_product(self._token, self._tenant, str(products[0]['id']))
+        product_label = sku_code or product_name
+        full = await self._product_detail(product_name=product_name, sku_code=sku_code)
         product = full.get('product') or {}
         skus: list[dict[str, Any]] = full.get('skus') or []  # type: ignore[assignment]
         sizes: list[dict[str, Any]] = full.get('sizes') or []  # type: ignore[assignment]
 
+        requested_sku_code = str(sku_code or '').strip().upper()
+        if requested_sku_code:
+            sku_matches = [
+                sku for sku in skus if str(sku.get('sku_code') or '').strip().upper() == requested_sku_code
+            ]
+            if not sku_matches:
+                raise ValueError(f'SKU "{requested_sku_code}" was not found for "{product_label}".')
+            candidate_skus = sku_matches
+        else:
+            candidate_skus = skus
+
         available_colors = sorted(
             {
                 str(sku.get('color_name')).strip()
-                for sku in skus
+                for sku in candidate_skus
                 if isinstance(sku.get('color_name'), str) and str(sku.get('color_name')).strip()
             }
         )
 
-        if color_name:
+        if color_name and not requested_sku_code:
             cnl = color_name.lower()
-            colour_skus = [s for s in skus if cnl in str(s.get('color_name') or '').lower()]
+            colour_skus = [s for s in candidate_skus if cnl in str(s.get('color_name') or '').lower()]
             if not colour_skus:
                 available = ', '.join(available_colors[:10]) or 'none'
-                raise ValueError(f'Color "{color_name}" not found for "{product_name}". Available: {available}')
+                raise ValueError(f'Color "{color_name}" not found for "{product_label}". Available: {available}')
             candidate_skus = colour_skus
-        else:
+        elif not requested_sku_code:
             if len(available_colors) > 1:
-                available = ', '.join(available_colors[:10])
-                raise ValueError(f'Color is required for "{product_name}". Available: {available}')
-            candidate_skus = skus
+                raise ValueError(self._variant_prompt(product_label, skus, sizes))
 
         candidate_ids = {str(s['id']) for s in candidate_skus}
         sku_by_id = {str(s['id']): s for s in candidate_skus}
@@ -186,20 +328,30 @@ class EntityResolver:
                 raw_price = product.get('base_price')
             if raw_price is None:
                 raise ValueError(
-                    f'Unit price is not configured for "{product_name}" {color_name or ""} {size_label}'.strip()
+                    f'Unit price is not configured for "{product_label}" {color_name or ""} {size_label}'.strip()
                 )
             return int(raw_price)
 
+        base_price = product.get('base_price')
+        if base_price is None:
+            raise ValueError(
+                f'Base price is not configured for "{product_label}". Provide unit cost explicitly or set the product base price.'
+            )
+
+        def resolved_unit_cost() -> int:
+            return int(base_price)
+
         if not sl:
-            if len(available_sizes) > 1:
-                available = ', '.join(available_sizes[:10]) or 'none'
-                raise ValueError(
-                    f'Size is required for "{product_name}" {color_name or ""}. Available: {available}'.strip()
-                )
+            if len(available_sizes) > 1 or len(candidate_sizes) > 1:
+                raise ValueError(self._variant_prompt(product_label, candidate_skus, candidate_sizes))
             if len(candidate_sizes) == 1:
                 size = candidate_sizes[0]
-                return {'sizeId': str(size['id']), 'unitPrice': effective_unit_price(size)}
-            raise ValueError(f'Size is required for "{product_name}" {color_name or ""}.'.strip())
+                return {
+                    'sizeId': str(size['id']),
+                    'unitPrice': effective_unit_price(size),
+                    'unitCost': resolved_unit_cost(),
+                }
+            raise ValueError(f'Size is required for "{product_label}" {color_name or ""}.'.strip())
 
         exact_matches = [
             size
@@ -208,7 +360,11 @@ class EntityResolver:
         ]
         if len(exact_matches) == 1:
             size = exact_matches[0]
-            return {'sizeId': str(size['id']), 'unitPrice': effective_unit_price(size)}
+            return {
+                'sizeId': str(size['id']),
+                'unitPrice': effective_unit_price(size),
+                'unitCost': resolved_unit_cost(),
+            }
 
         partial_matches = [
             size
@@ -217,11 +373,15 @@ class EntityResolver:
         ]
         if len(partial_matches) == 1:
             size = partial_matches[0]
-            return {'sizeId': str(size['id']), 'unitPrice': effective_unit_price(size)}
+            return {
+                'sizeId': str(size['id']),
+                'unitPrice': effective_unit_price(size),
+                'unitCost': resolved_unit_cost(),
+            }
 
         available = ', '.join(available_sizes[:10])
         raise ValueError(
-            f'Size "{size_label}" not found for "{product_name}". Available: {available or "none"}'
+            f'Size "{size_label}" not found for "{product_label}". Available: {available or "none"}'
         )
 
     async def size_from_payload(self, payload: dict[str, Any]) -> str:
@@ -239,6 +399,25 @@ class EntityResolver:
         details = await self.sku_size_details(product_name, size_label, color_name)
         return str(details['sizeId'])
 
+    async def _cached_rows(
+        self,
+        key: str,
+        loader,
+    ) -> list[dict[str, object]]:
+        cached = self._cache.get(key)
+        if isinstance(cached, list):
+            return cached
+        rows = await loader()
+        self._cache[key] = rows
+        return rows
+
+    async def _cached_value(self, key: str, loader):
+        if key in self._cache:
+            return self._cache[key]
+        value = await loader()
+        self._cache[key] = value
+        return value
+
     async def size_lines_from_product(
         self,
         product_name: str,
@@ -247,7 +426,7 @@ class EntityResolver:
         size_labels: list[str] | None = None,
     ) -> list[dict[str, str]]:
         """Expand a product reference into concrete size rows for matching colours/sizes."""
-        products = await self._backend.search_products(self._token, self._tenant, q=product_name)
+        products = self._product_rows(await self._backend.search_products(self._token, self._tenant, q=product_name))
         if not products:
             raise ValueError(f'Product "{product_name}" not found.')
 
@@ -311,3 +490,276 @@ class EntityResolver:
         ]
         rows.sort(key=lambda row: (row['colorName'], row['sizeLabel']))
         return rows
+
+    @staticmethod
+    def _product_rows(payload: object) -> list[dict[str, Any]]:
+        if isinstance(payload, list):
+            return [item for item in payload if isinstance(item, dict)]
+        if isinstance(payload, dict):
+            items = payload.get('items')
+            if isinstance(items, list):
+                return [item for item in items if isinstance(item, dict)]
+        return []
+
+    async def _product_detail(
+        self,
+        *,
+        product_name: str,
+        sku_code: str | None = None,
+    ) -> dict[str, Any]:
+        requested_sku_code = str(sku_code or '').strip().upper()
+        if requested_sku_code:
+            sku_matches = await self._backend.search_skus(self._token, self._tenant, requested_sku_code)
+            exact = None
+            for candidate in sku_matches:
+                code = str(candidate.get('sku_code') or '').strip().upper()
+                if code == requested_sku_code:
+                    exact = candidate
+                    break
+            candidate = exact or (sku_matches[0] if sku_matches else None)
+            if isinstance(candidate, dict) and candidate.get('product_id'):
+                return await self._backend.get_product(self._token, self._tenant, str(candidate['product_id']))
+
+        products = self._product_rows(await self._backend.search_products(self._token, self._tenant, q=product_name))
+        if not products:
+            label = requested_sku_code or product_name
+            raise ValueError(f'Product "{label}" not found.')
+        return await self._backend.get_product(self._token, self._tenant, str(products[0]['id']))
+
+    @staticmethod
+    def _variant_prompt(
+        product_label: str,
+        skus: list[dict[str, Any]],
+        sizes: list[dict[str, Any]],
+    ) -> str:
+        color_by_sku_id = {
+            str(sku.get('id')): str(sku.get('color_name') or '').strip()
+            for sku in skus
+            if str(sku.get('id') or '').strip()
+        }
+        options = sorted(
+            {
+                ' / '.join(
+                    part
+                    for part in (
+                        color_by_sku_id.get(str(size.get('sku_id')), ''),
+                        str(size.get('size_label') or '').strip().upper(),
+                    )
+                    if part
+                )
+                for size in sizes
+                if str(size.get('id') or '').strip()
+            }
+        )
+        available = ', '.join(option for option in options[:12] if option) or 'none'
+        return (
+            f'Multiple variants are available for "{product_label}". '
+            f'Which variant should I use? Available variants: {available}.'
+        )
+
+    @staticmethod
+    def _require_resolved(result: ResolutionResult) -> str:
+        if result.status in {'resolved', 'relative_reference'} and result.value:
+            return result.value
+        raise ResolutionError(result)
+
+    def _relative_context_value(
+        self,
+        query: str,
+        *,
+        terms: tuple[str, ...],
+        value_keys: tuple[str, ...],
+    ) -> ResolutionResult | None:
+        normalized_query = query.strip().lower()
+        if normalized_query not in terms:
+            return None
+        for key in value_keys:
+            value = self._context_entities.get(key)
+            if isinstance(value, str) and value.strip():
+                return ResolutionResult(status='relative_reference', value=value.strip())
+        missing_label = terms[0]
+        return ResolutionResult(
+            status='not_found',
+            message=f'I do not have an active reference for "{missing_label}". Please specify the exact record.',
+        )
+
+    def _latest_list_reference(
+        self,
+        query: str,
+        *,
+        terms: tuple[str, ...],
+        rows: list[dict[str, object]],
+        label_fields: tuple[str, ...],
+        singular: str,
+    ) -> ResolutionResult | None:
+        normalized_query = query.strip().lower()
+        if normalized_query not in terms:
+            return None
+        if not rows:
+            return ResolutionResult(
+                status='not_found',
+                message=f'I could not find any {singular}s to use as the latest reference.',
+            )
+        identifier = str(rows[0].get('id') or '').strip()
+        if not identifier:
+            return ResolutionResult(
+                status='not_found',
+                message=f'The latest {singular} is missing an id.',
+            )
+        return ResolutionResult(status='relative_reference', value=identifier)
+
+    def _latest_reference_for_party(
+        self,
+        query: str,
+        *,
+        rows: list[dict[str, object]],
+        pattern: re.Pattern[str],
+        scope_fields: tuple[str, ...],
+        label_fields: tuple[str, ...],
+        singular: str,
+        party_label: str,
+    ) -> ResolutionResult | None:
+        match = pattern.match(query.strip())
+        if not match:
+            return None
+        scope_query = str(match.group(1) or '').strip().lower()
+        if not scope_query:
+            return ResolutionResult(
+                status='not_found',
+                message=f'Which {party_label} should I use for the latest {singular} reference?',
+            )
+
+        exact_matches = self._matching_rows(rows, scope_query, scope_fields, exact=True)
+        partial_matches = self._matching_rows(rows, scope_query, scope_fields, exact=False)
+        matches = exact_matches or partial_matches
+        if not matches:
+            return ResolutionResult(
+                status='not_found',
+                message=f'No {singular} found for {party_label} "{match.group(1).strip()}".',
+            )
+
+        distinct_labels = {
+            self._candidate_label(row, scope_fields)
+            for row in matches
+            if self._candidate_label(row, scope_fields)
+        }
+        if len(distinct_labels) > 1 and not exact_matches:
+            return self._ambiguous_result(
+                match.group(1).strip(),
+                matches,
+                label_fields=label_fields,
+                singular=singular,
+                plural=f'{singular}s',
+            )
+
+        identifier = str(matches[0].get('id') or '').strip()
+        if not identifier:
+            return ResolutionResult(
+                status='not_found',
+                message=f'The latest {singular} for {party_label} "{match.group(1).strip()}" is missing an id.',
+            )
+        return ResolutionResult(status='relative_reference', value=identifier)
+
+    def _resolve_named_entity(
+        self,
+        rows: list[dict[str, object]],
+        query: str,
+        *,
+        match_fields: tuple[str, ...],
+        label_fields: tuple[str, ...],
+        singular: str,
+        plural: str,
+    ) -> ResolutionResult:
+        normalized_query = query.strip().lower()
+        if not normalized_query:
+            return ResolutionResult(
+                status='not_found',
+                message=f'{singular.title()} reference is required.',
+            )
+
+        exact_matches = self._matching_rows(rows, normalized_query, match_fields, exact=True)
+        if len(exact_matches) == 1:
+            return ResolutionResult(status='resolved', value=str(exact_matches[0]['id']))
+        if len(exact_matches) > 1:
+            return self._ambiguous_result(query, exact_matches, label_fields=label_fields, singular=singular, plural=plural)
+
+        partial_matches = self._matching_rows(rows, normalized_query, match_fields, exact=False)
+        if len(partial_matches) == 1:
+            return ResolutionResult(status='resolved', value=str(partial_matches[0]['id']))
+        if len(partial_matches) > 1:
+            return self._ambiguous_result(query, partial_matches, label_fields=label_fields, singular=singular, plural=plural)
+
+        return ResolutionResult(
+            status='not_found',
+            message=f'{singular.title()} "{query}" not found. Search to see available {plural}.',
+        )
+
+    def _ambiguous_result(
+        self,
+        query: str,
+        rows: list[dict[str, object]],
+        *,
+        label_fields: tuple[str, ...],
+        singular: str,
+        plural: str,
+    ) -> ResolutionResult:
+        candidates = tuple(
+            ResolutionCandidate(
+                id=str(row.get('id') or ''),
+                label=self._candidate_label(row, label_fields),
+            )
+            for row in rows[:5]
+            if str(row.get('id') or '').strip()
+        )
+        options = ', '.join(candidate.label for candidate in candidates) or 'none'
+        return ResolutionResult(
+            status='ambiguous',
+            message=(
+                f'I found multiple {plural} matching "{query}". '
+                f'Which {singular} should I use? Options: {options}.'
+            ),
+            candidates=candidates,
+        )
+
+    @staticmethod
+    def _matching_rows(
+        rows: list[dict[str, object]],
+        normalized_query: str,
+        fields: tuple[str, ...],
+        *,
+        exact: bool,
+    ) -> list[dict[str, object]]:
+        matches: list[dict[str, object]] = []
+        seen_ids: set[str] = set()
+        for row in rows:
+            row_id = str(row.get('id') or '').strip()
+            if not row_id or row_id in seen_ids:
+                continue
+            for field in fields:
+                value = str(row.get(field) or '').strip().lower()
+                if not value:
+                    continue
+                if exact and value == normalized_query:
+                    matches.append(row)
+                    seen_ids.add(row_id)
+                    break
+                if not exact and normalized_query in value:
+                    matches.append(row)
+                    seen_ids.add(row_id)
+                    break
+        return matches
+
+    @staticmethod
+    def _candidate_label(row: dict[str, object], label_fields: tuple[str, ...]) -> str:
+        values = [str(row.get(field) or '').strip() for field in label_fields]
+        values = [value for value in values if value]
+        if not values:
+            return str(row.get('id') or '').strip()
+        primary = values[0]
+        extras: list[str] = []
+        for value in values[1:]:
+            if value != primary and value not in extras:
+                extras.append(value)
+        if not extras:
+            return primary
+        return f'{primary} ({", ".join(extras[:2])})'

--- a/conversational-engine/src/conversational_engine/tools/validation.py
+++ b/conversational-engine/src/conversational_engine/tools/validation.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationIssue:
+    path: tuple[str, ...]
+    message: str
+
+    def render(self) -> str:
+        if not self.path:
+            return self.message
+        return f'{".".join(self.path)}: {self.message}'
+
+
+class ToolSchemaValidationError(ValueError):
+    def __init__(self, issues: list[ValidationIssue]) -> None:
+        self.issues = issues
+        message = '; '.join(issue.render() for issue in issues) or 'Tool payload is invalid.'
+        super().__init__(message)
+
+    @property
+    def required_fields(self) -> list[str]:
+        fields: list[str] = []
+        for issue in self.issues:
+            if issue.path:
+                fields.append('.'.join(issue.path))
+        return fields
+
+    @property
+    def prompt(self) -> str:
+        rendered = [issue.render() for issue in self.issues[:4]]
+        summary = '; '.join(rendered) if rendered else 'The tool payload is invalid.'
+        return f'I need to correct the request before I can continue: {summary}.'
+
+
+def validate_payload(schema: dict[str, Any], payload: Any) -> list[ValidationIssue]:
+    issues: list[ValidationIssue] = []
+    _validate(schema, payload, (), issues)
+    return issues
+
+
+def _validate(
+    schema: dict[str, Any],
+    value: Any,
+    path: tuple[str, ...],
+    issues: list[ValidationIssue],
+) -> None:
+    expected_types = _type_list(schema.get('type'))
+    if expected_types and not any(_matches_type(expected_type, value) for expected_type in expected_types):
+        issues.append(ValidationIssue(path, f'expected {"/".join(expected_types)}'))
+        return
+
+    if isinstance(value, dict):
+        _validate_object(schema, value, path, issues)
+        return
+
+    if isinstance(value, list):
+        _validate_array(schema, value, path, issues)
+        return
+
+    enum_values = schema.get('enum')
+    if isinstance(enum_values, list) and value not in enum_values:
+        issues.append(ValidationIssue(path, f'expected one of {", ".join(str(item) for item in enum_values)}'))
+
+
+def _validate_object(
+    schema: dict[str, Any],
+    value: dict[str, Any],
+    path: tuple[str, ...],
+    issues: list[ValidationIssue],
+) -> None:
+    properties = schema.get('properties')
+    required = schema.get('required')
+    additional_properties = schema.get('additionalProperties', True)
+
+    if isinstance(required, list):
+        for key in required:
+            if isinstance(key, str) and key not in value:
+                issues.append(ValidationIssue((*path, key), 'required'))
+
+    if isinstance(properties, dict):
+        for key, property_schema in properties.items():
+            if key not in value or not isinstance(property_schema, dict):
+                continue
+            _validate(property_schema, value[key], (*path, key), issues)
+
+    if additional_properties is False and isinstance(properties, dict):
+        allowed = set(properties.keys())
+        for key in value:
+            if key not in allowed:
+                issues.append(ValidationIssue((*path, str(key)), 'unexpected property'))
+
+
+def _validate_array(
+    schema: dict[str, Any],
+    value: list[Any],
+    path: tuple[str, ...],
+    issues: list[ValidationIssue],
+) -> None:
+    min_items = schema.get('minItems')
+    if isinstance(min_items, int) and len(value) < min_items:
+        issues.append(ValidationIssue(path, f'expected at least {min_items} item(s)'))
+
+    items_schema = schema.get('items')
+    if isinstance(items_schema, dict):
+        for index, item in enumerate(value):
+            _validate(items_schema, item, (*path, str(index)), issues)
+
+
+def _type_list(raw_type: Any) -> list[str]:
+    if isinstance(raw_type, str):
+        return [raw_type]
+    if isinstance(raw_type, list):
+        return [item for item in raw_type if isinstance(item, str)]
+    return []
+
+
+def _matches_type(expected_type: str, value: Any) -> bool:
+    if expected_type == 'object':
+        return isinstance(value, dict)
+    if expected_type == 'array':
+        return isinstance(value, list)
+    if expected_type == 'string':
+        return isinstance(value, str)
+    if expected_type == 'integer':
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected_type == 'number':
+        return (isinstance(value, int) or isinstance(value, float)) and not isinstance(value, bool)
+    if expected_type == 'boolean':
+        return isinstance(value, bool)
+    if expected_type == 'null':
+        return value is None
+    return True

--- a/conversational-engine/src/conversational_engine/training/redaction.py
+++ b/conversational-engine/src/conversational_engine/training/redaction.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
-EMAIL_RE = re.compile(r'[\w.+-]+@[\w.-]+\.\w+')
+EMAIL_RE = re.compile(r'[A-Za-z0-9._+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}')
 UUID_RE = re.compile(r'\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b', re.IGNORECASE)
 TOKEN_RE = re.compile(r'Bearer\s+[A-Za-z0-9._-]+', re.IGNORECASE)
 PHONE_RE = re.compile(r'\b(?:\+\d{1,3}[\s.-]?)?(?:\(?\d{2,4}\)?[\s.-]?){2,3}\d{3,4}\b')

--- a/conversational-engine/src/conversational_engine/utils/casing.py
+++ b/conversational-engine/src/conversational_engine/utils/casing.py
@@ -1,3 +1,5 @@
 def to_camel(value: str) -> str:
-    parts = value.split('_')
+    parts = [part for part in value.split('_') if part]
+    if not parts:
+        return ''
     return parts[0] + ''.join(part.capitalize() for part in parts[1:])

--- a/conversational-engine/src/conversational_engine/utils/json_parsing.py
+++ b/conversational-engine/src/conversational_engine/utils/json_parsing.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def strip_markdown_fences(raw: str) -> str:
+    cleaned = raw.strip()
+    if cleaned.startswith('```'):
+        lines = cleaned.splitlines()
+        if lines:
+            lines = lines[1:]
+        while lines and lines[-1].strip() == '```':
+            lines = lines[:-1]
+        cleaned = '\n'.join(lines).strip()
+    return cleaned
+
+
+def parse_json_value(raw: str, *, source: str) -> Any:
+    cleaned = strip_markdown_fences(raw)
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f'{source} returned invalid JSON: {exc.msg}') from exc
+
+
+def parse_json_object(raw: str, *, source: str) -> dict[str, Any]:
+    parsed = parse_json_value(raw, source=source)
+    if not isinstance(parsed, dict):
+        raise RuntimeError(f'{source} returned a non-object JSON payload')
+    return parsed

--- a/conversational-engine/tests/test_backend_client.py
+++ b/conversational-engine/tests/test_backend_client.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from conversational_engine.clients.backend import BackendClient
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_backend_client_retries_transient_get_failures() -> None:
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise httpx.ConnectError('temporary outage', request=request)
+        return httpx.Response(200, json=[{'id': 'loc-1'}])
+
+    client = BackendClient('http://backend.test', retry_attempts=3)
+    original_client = client._client
+    client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    await original_client.aclose()
+    try:
+        payload = await client.list_locations('token', 'tenant-1')
+    finally:
+        await client.aclose()
+
+    assert attempts == 3
+    assert payload == [{'id': 'loc-1'}]
+
+
+async def test_backend_client_retries_mutations_with_stable_idempotency_key() -> None:
+    seen_keys: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_keys.append(request.headers['Idempotency-Key'])
+        if len(seen_keys) == 1:
+            return httpx.Response(503, json={'message': 'unavailable'})
+        return httpx.Response(200, json={'id': 'customer-1'})
+
+    client = BackendClient('http://backend.test', retry_attempts=2)
+    original_client = client._client
+    client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    await original_client.aclose()
+    try:
+        payload = await client.create_customer('token', 'tenant-1', {'name': 'Acme'})
+    finally:
+        await client.aclose()
+
+    assert payload == {'id': 'customer-1'}
+    assert len(seen_keys) == 2
+    assert seen_keys[0] == seen_keys[1]

--- a/conversational-engine/tests/test_contracts.py
+++ b/conversational-engine/tests/test_contracts.py
@@ -1,3 +1,6 @@
+import pytest
+from pydantic import ValidationError
+
 from uuid import uuid4
 
 from conversational_engine.contracts.api import ConversationResponse
@@ -12,6 +15,8 @@ from conversational_engine.contracts.common import (
     WorkflowState,
     WorkflowStatus,
 )
+from conversational_engine.contracts.runs import RunRequest
+from conversational_engine.utils.casing import to_camel
 from conversational_engine.utils.time import utc_now
 
 
@@ -56,3 +61,12 @@ def test_conversation_response_serializes_camel_case_aliases():
     assert payload['workflow']['currentTask'] == 'stock_transfer'
     assert payload['messages'][0]['blocks'][1]['type'] == 'confirmation_required'
     assert payload['messages'][0]['blocks'][1]['allowedActions'] == ['confirm', 'cancel']
+
+
+def test_run_request_enforces_content_length():
+    with pytest.raises(ValidationError):
+        RunRequest(content='x' * 4001)
+
+
+def test_to_camel_skips_empty_underscore_parts():
+    assert to_camel('__pending_action') == 'pendingAction'

--- a/conversational-engine/tests/test_conversation_service.py
+++ b/conversational-engine/tests/test_conversation_service.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from conversational_engine.ai.repository import ConversationFetchResult, MessagePage
+from conversational_engine.config.settings import Settings
+from conversational_engine.contracts.auth import AuthContext
+from conversational_engine.contracts.common import ConversationDetail, WorkflowState, WorkflowStatus
+from conversational_engine.conversations.service import ConversationService
+
+pytestmark = pytest.mark.anyio
+
+
+class FakeRepository:
+    def __init__(self, conversation: ConversationDetail) -> None:
+        self._conversation = conversation
+
+    async def get_conversation(self, *args, **kwargs):
+        del args, kwargs
+        return ConversationFetchResult(
+            conversation=self._conversation,
+            workflow=WorkflowState(id=uuid4(), status=WorkflowStatus.IDLE),
+            page=MessagePage(messages=[]),
+        )
+
+    def build_pending_action(self, workflow):
+        del workflow
+        return None
+
+    async def find_workflow_by_id(self, *args, **kwargs):
+        del args, kwargs
+        return None
+
+
+class FakeBackendClient:
+    def __init__(self, conversation_id, workflow_id) -> None:
+        self._conversation_id = conversation_id
+        self._workflow_id = workflow_id
+
+    async def get_approval_request(self, *args, **kwargs):
+        del args, kwargs
+        return SimpleNamespace(
+            id=uuid4(),
+            conversation_id=self._conversation_id,
+            workflow_id=self._workflow_id,
+            status='rejected',
+            action_type='products.create_product',
+            tool_name='products.create_product',
+            summary='Create product',
+            execution_payload={'styleCode': 'TEE-1'},
+        )
+
+    async def decide_approval(self, *args, **kwargs):
+        del args, kwargs
+        return SimpleNamespace(status='rejected')
+
+
+class FakeAuditService:
+    def __init__(self) -> None:
+        self.events: list[dict[str, object]] = []
+
+    async def record(self, **kwargs):
+        self.events.append(kwargs)
+        return kwargs
+
+
+def make_auth(*, user_id: str, permissions: list[str] | None = None) -> AuthContext:
+    return AuthContext(
+        id=user_id,
+        tenant_id='tenant-1',
+        role_id='role-1',
+        email='ops@example.com',
+        permissions=permissions or ['chat.use'],
+        access_token='token',
+    )
+
+
+def make_service(conversation: ConversationDetail) -> ConversationService:
+    repository = FakeRepository(conversation)
+    return ConversationService(
+        repository=repository,  # type: ignore[arg-type]
+        backend_client=SimpleNamespace(),  # type: ignore[arg-type]
+        runtime_service=SimpleNamespace(),  # type: ignore[arg-type]
+        audit_service=None,
+        attachment_service=SimpleNamespace(),  # type: ignore[arg-type]
+        redis_cache=SimpleNamespace(),  # type: ignore[arg-type]
+        settings=Settings(),
+    )
+
+
+async def test_conversation_service_rejects_non_owner_access():
+    now = datetime.now(UTC)
+    service = make_service(
+        ConversationDetail(
+            id=uuid4(),
+            title='Restricted',
+            created_by='owner-1',
+            created_at=now,
+            updated_at=now,
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.get_conversation(make_auth(user_id='user-2'), uuid4())
+
+    assert exc_info.value.status_code == 403
+
+
+async def test_conversation_service_allows_admin_access():
+    now = datetime.now(UTC)
+    service = make_service(
+        ConversationDetail(
+            id=uuid4(),
+            title='Restricted',
+            created_by='owner-1',
+            created_at=now,
+            updated_at=now,
+        )
+    )
+
+    response = await service.get_conversation(
+        make_auth(user_id='user-2', permissions=['tenant.admin']),
+        uuid4(),
+    )
+
+    assert response is not None
+    assert response.conversation.created_by == 'owner-1'
+
+
+async def test_conversation_service_records_approval_rejections():
+    now = datetime.now(UTC)
+    conversation_id = uuid4()
+    workflow_id = uuid4()
+    audit = FakeAuditService()
+    service = ConversationService(
+        repository=FakeRepository(
+            ConversationDetail(
+                id=conversation_id,
+                title='Restricted',
+                created_by='owner-1',
+                created_at=now,
+                updated_at=now,
+            )
+        ),  # type: ignore[arg-type]
+        backend_client=FakeBackendClient(conversation_id, workflow_id),  # type: ignore[arg-type]
+        runtime_service=SimpleNamespace(),  # type: ignore[arg-type]
+        audit_service=audit,  # type: ignore[arg-type]
+        attachment_service=SimpleNamespace(),  # type: ignore[arg-type]
+        redis_cache=SimpleNamespace(),  # type: ignore[arg-type]
+        settings=Settings(),
+    )
+
+    response = await service.apply_approval_decision(make_auth(user_id='owner-1'), uuid4(), False)
+
+    assert response.status == 'rejected'
+    assert audit.events[0]['event_type'] == 'approval_rejected'
+    assert audit.events[0]['workflow_id'] == str(workflow_id)

--- a/conversational-engine/tests/test_executor_agent.py
+++ b/conversational-engine/tests/test_executor_agent.py
@@ -187,3 +187,163 @@ async def test_executor_accepts_parameters_alias():
         'basePrice': 21,
         'variants': [{'sizeLabel': 'XL', 'colorName': 'red'}],
     }
+
+
+class MarkdownFenceRouter:
+    async def complete_json(self, **kwargs):
+        del kwargs
+        return ProviderResponse(
+            provider_name='openai',
+            model_name='gpt-4.1-mini',
+            content='{}',
+            parsed={
+                'action': 'tool',
+                'assistantMessage': 'Creating product.',
+                'toolName': 'products.create_product',
+                'toolArguments': None,
+                'toolArgumentsJson': '```json\n{"styleCode":"SAI-12","name":"sai","basePrice":21}\n```',
+                'requiredInputs': [],
+            },
+            raw_payload={},
+        )
+
+
+async def test_executor_strips_markdown_fences_from_tool_arguments_json():
+    agent = ExecutorAgent(MarkdownFenceRouter())  # type: ignore[arg-type]
+
+    proposal = await agent.propose(
+        user_message='create a product',
+        plan={'action': 'tool'},
+        tools=[],
+        history=[],
+    )
+
+    assert proposal['toolArguments'] == {
+        'styleCode': 'SAI-12',
+        'name': 'sai',
+        'basePrice': 21,
+    }
+
+
+class RootLevelProductArgumentsRouter:
+    async def complete_json(self, **kwargs):
+        del kwargs
+        return ProviderResponse(
+            provider_name='openai',
+            model_name='gpt-4.1-mini',
+            content='{}',
+            parsed={
+                'action': 'tool',
+                'assistantMessage': 'Creating product.',
+                'name': 'saitees',
+                'styleCode': 'sai-0204',
+                'basePrice': 100,
+                'variants': [{'colorName': 'black', 'sizes': [{'sizeLabel': 'XL'}]}],
+                'toolArguments': None,
+                'requiredInputs': [],
+            },
+            raw_payload={},
+        )
+
+
+async def test_executor_recovers_root_level_product_arguments_using_expected_tool_name():
+    agent = ExecutorAgent(RootLevelProductArgumentsRouter())  # type: ignore[arg-type]
+
+    proposal = await agent.propose(
+        user_message='create a product named saitees with style code sai-0204 in black xl at 100',
+        plan={'action': 'tool'},
+        tools=[],
+        history=[],
+        expected_tool_name='products.create_product',
+    )
+
+    assert proposal['toolName'] == 'products.create_product'
+    assert proposal['toolArguments'] == {
+        'name': 'saitees',
+        'styleCode': 'sai-0204',
+        'basePrice': 100,
+        'variants': [{'colorName': 'black', 'sizes': [{'sizeLabel': 'XL'}]}],
+    }
+
+
+class DottedNameToolRouter:
+    async def complete_json(self, **kwargs):
+        del kwargs
+        return ProviderResponse(
+            provider_name='openai',
+            model_name='gpt-4.1-mini',
+            content='{}',
+            parsed={
+                'action': 'tool',
+                'assistantMessage': 'Creating supplier.',
+                'name': 'master.create_supplier',
+                'toolArguments': {
+                    'name': 'raghu',
+                    'email': 'raghu@bez.com',
+                    'phone': '190284039',
+                    'address': 'london',
+                },
+                'requiredInputs': [],
+            },
+            raw_payload={},
+        )
+
+
+async def test_executor_promotes_dotted_name_field_to_tool_name():
+    agent = ExecutorAgent(DottedNameToolRouter())  # type: ignore[arg-type]
+
+    proposal = await agent.propose(
+        user_message='create supplier raghu with email raghu@bez.com phone 190284039 address london',
+        plan={'action': 'tool'},
+        tools=[],
+        history=[],
+    )
+
+    assert proposal['toolName'] == 'master.create_supplier'
+    assert proposal['toolArguments'] == {
+        'name': 'raghu',
+        'email': 'raghu@bez.com',
+        'phone': '190284039',
+        'address': 'london',
+    }
+
+
+class RootLevelSupplierArgumentsRouter:
+    async def complete_json(self, **kwargs):
+        del kwargs
+        return ProviderResponse(
+            provider_name='openai',
+            model_name='gpt-4.1-mini',
+            content='{}',
+            parsed={
+                'action': 'tool',
+                'assistantMessage': 'Creating supplier.',
+                'name': 'raghu',
+                'email': '[raghu@bez.com](mailto:raghu@bez.com)',
+                'phone': '190284039',
+                'address': 'london',
+                'toolArguments': None,
+                'requiredInputs': [],
+            },
+            raw_payload={},
+        )
+
+
+async def test_executor_recovers_root_level_supplier_arguments_using_expected_tool_name():
+    agent = ExecutorAgent(RootLevelSupplierArgumentsRouter())  # type: ignore[arg-type]
+
+    proposal = await agent.propose(
+        user_message='create supplier raghu with email raghu@bez.com phone 190284039 address london',
+        plan={'action': 'tool'},
+        tools=[],
+        history=[],
+        expected_tool_name='master.create_supplier',
+    )
+
+    assert proposal['toolName'] == 'master.create_supplier'
+    assert proposal['toolArguments'] == {
+        'name': 'raghu',
+        'email': '[raghu@bez.com](mailto:raghu@bez.com)',
+        'phone': '190284039',
+        'address': 'london',
+    }

--- a/conversational-engine/tests/test_orchestrator.py
+++ b/conversational-engine/tests/test_orchestrator.py
@@ -17,6 +17,7 @@ from conversational_engine.config.model_routing import ModelRouting
 from conversational_engine.contracts.api import ApprovalRequestStatus, GovernanceEvaluationResponse
 from conversational_engine.contracts.auth import AuthContext
 from conversational_engine.contracts.common import BlockType, ConversationDetail, WorkflowState, WorkflowStatus
+from conversational_engine.orchestrator.intents import classify_intent
 from conversational_engine.orchestrator.service import OrchestratorService
 from conversational_engine.providers.base import ChatProvider, ProviderMessage
 
@@ -264,6 +265,21 @@ async def test_product_create_does_not_require_category():
     assert any(block.type == BlockType.PREVIEW for block in outcome.blocks)
 
 
+async def test_orchestrator_redirects_off_topic_questions():
+    service = make_service()
+
+    outcome = await service.handle_message(
+        make_auth(),
+        make_conversation(),
+        make_workflow(),
+        'what is the size of the earth',
+    )
+
+    assert outcome.status == WorkflowStatus.COMPLETED
+    assert outcome.blocks[0].type == BlockType.TEXT
+    assert 'inventory' in outcome.blocks[0].content.lower()
+
+
 async def test_create_a_product_phrase_routes_to_product_workflow():
     service = make_service()
 
@@ -398,3 +414,18 @@ async def test_inventory_receipt_does_not_require_reason():
     assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
     assert 'reason' not in outcome.missing_fields
     assert any(block.type == BlockType.PREVIEW for block in outcome.blocks)
+
+
+def test_classify_intent_prefers_fresh_pending_task_for_short_follow_up():
+    intent = classify_intent(
+        'blue',
+        {
+            'pendingTask': {
+                'intent': 'product_create',
+                'missingFields': ['color_name'],
+                'updatedAt': datetime.now(UTC).isoformat(),
+            }
+        },
+    )
+
+    assert intent == 'product_create'

--- a/conversational-engine/tests/test_parsing_utils.py
+++ b/conversational-engine/tests/test_parsing_utils.py
@@ -1,0 +1,6 @@
+from conversational_engine.agents.parsing import parse_money
+
+
+def test_parse_money_converts_decimal_amounts_to_cents():
+    assert parse_money('base price 25.50 usd') == 2550
+    assert parse_money('@12.99') == 1299

--- a/conversational-engine/tests/test_redaction.py
+++ b/conversational-engine/tests/test_redaction.py
@@ -20,3 +20,11 @@ def test_redact_text_covers_common_secrets_and_identifiers():
     assert '[redacted-aws-secret]' in redacted
     assert '[redacted-secret]' in redacted
     assert '[redacted-uuid]' in redacted
+
+
+def test_redact_text_ignores_invalid_email_like_strings():
+    value = 'not-an-email@ localhost user@@example'
+
+    redacted = redact_text(value)
+
+    assert redacted == value

--- a/conversational-engine/tests/test_runtime_decisions.py
+++ b/conversational-engine/tests/test_runtime_decisions.py
@@ -5,8 +5,9 @@ from uuid import UUID, uuid4
 import pytest
 
 from conversational_engine.contracts.auth import AuthContext
-from conversational_engine.contracts.common import BlockType, WorkflowState, WorkflowStatus
+from conversational_engine.contracts.common import BlockType, TextBlock, WorkflowState, WorkflowStatus
 from conversational_engine.conversations.runtime_decisions import RuntimeDecisionHandler
+from conversational_engine.runtime.contracts import RuntimeOutcome
 
 pytestmark = pytest.mark.anyio
 
@@ -40,6 +41,54 @@ class FakeBackendClient:
         del args, kwargs
         return {'ok': True}
 
+    async def create_supplier(self, *args, **kwargs):
+        del args, kwargs
+        return {'ok': True, 'id': 'sup-created', 'name': 'Fashion Hub'}
+
+
+class FakeRuntimeService:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def execute(self, **kwargs):
+        self.calls.append(kwargs)
+        extracted_entities = dict(kwargs['extracted_entities'])
+        assert extracted_entities['supplierId'] == 'sup-created'
+        assert 'compoundQueue' not in extracted_entities
+        return RuntimeOutcome(
+            blocks=[TextBlock(content='Prepared the next purchase order draft.')],
+            status=WorkflowStatus.AWAITING_CONFIRMATION,
+            current_task='awaiting_confirmation',
+            extracted_entities={
+                '_workflowEngine': 'runtime',
+                'toolName': 'purchasing.create_po',
+                'executionPayload': {
+                    'supplierId': 'sup-created',
+                    'lines': [{'sizeId': 'size-red-s', 'qty': 20, 'unitCost': 18}],
+                },
+                'taskContext': {
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'purchasing.create_po',
+                    'entities': {
+                        'supplierId': 'sup-created',
+                    },
+                    'missingFields': [],
+                    'postActions': [],
+                    'clarificationCount': 0,
+                    'status': 'awaiting_confirmation',
+                },
+            },
+        )
+
+
+class FakeAuditService:
+    def __init__(self) -> None:
+        self.events: list[dict[str, object]] = []
+
+    async def record(self, **kwargs):
+        self.events.append(kwargs)
+        return kwargs
+
 
 def make_auth() -> AuthContext:
     return AuthContext(
@@ -53,7 +102,8 @@ def make_auth() -> AuthContext:
 
 
 async def test_runtime_decision_confirm_routes_to_approval_when_required():
-    handler = RuntimeDecisionHandler(FakeBackendClient())  # type: ignore[arg-type]
+    audit = FakeAuditService()
+    handler = RuntimeDecisionHandler(FakeBackendClient(), audit_service=audit)  # type: ignore[arg-type]
     workflow = WorkflowState(
         id=uuid4(),
         status=WorkflowStatus.AWAITING_CONFIRMATION,
@@ -81,6 +131,8 @@ async def test_runtime_decision_confirm_routes_to_approval_when_required():
 
     assert outcome.status == WorkflowStatus.AWAITING_APPROVAL
     assert any(block.type == BlockType.APPROVAL_PENDING for block in outcome.blocks)
+    assert audit.events[0]['event_type'] == 'approval_created'
+    assert audit.events[0]['tool_name'] == 'products.create_product'
 
 
 async def test_runtime_decision_edit_returns_to_needs_input():
@@ -195,3 +247,54 @@ async def test_runtime_decision_cancel_keeps_original_pending_approval():
     assert outcome.status == WorkflowStatus.AWAITING_APPROVAL
     assert outcome.active_approval_id == approval_id
     assert any(block.type == BlockType.APPROVAL_PENDING for block in outcome.blocks)
+
+
+async def test_runtime_decision_confirm_advances_compound_queue_after_execution():
+    runtime_service = FakeRuntimeService()
+    handler = RuntimeDecisionHandler(
+        FakeBackendClient(),
+        runtime_service=runtime_service,  # type: ignore[arg-type]
+    )
+    workflow = WorkflowState(
+        id=uuid4(),
+        status=WorkflowStatus.AWAITING_CONFIRMATION,
+        current_task='awaiting_confirmation',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            '_pendingActions': ['confirm', 'cancel', 'edit'],
+            '_pendingPrompt': 'Review and confirm.',
+            'toolName': 'master.create_supplier',
+            'executionPayload': {
+                'name': 'Fashion Hub',
+                'phone': '020-123-4567',
+                'address': '10 Avenue',
+            },
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'master.create_supplier',
+                'entities': {},
+                'missingFields': [],
+                'postActions': [],
+                'clarificationCount': 0,
+                'status': 'awaiting_confirmation',
+            },
+            'compoundQueue': ['create PO for Classic Shirt Red S x20 @18'],
+        },
+    )
+
+    outcome = await handler.apply(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=workflow.id,
+        workflow=workflow,
+        decision='confirm',
+    )
+
+    assert len(runtime_service.calls) == 1
+    assert runtime_service.calls[0]['user_message'] == 'create PO for Classic Shirt Red S x20 @18'
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['toolName'] == 'purchasing.create_po'
+    assert any(
+        block.type == BlockType.TEXT and 'Prepared the next purchase order draft.' in block.content
+        for block in outcome.blocks
+    )

--- a/conversational-engine/tests/test_runtime_service.py
+++ b/conversational-engine/tests/test_runtime_service.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import pytest
 
+from conversational_engine.clients.backend import BackendValidationError
 from conversational_engine.contracts.api import ApprovalRequestStatus, GovernanceEvaluationResponse
 from conversational_engine.contracts.auth import AuthContext
 from conversational_engine.contracts.common import BlockType, WorkflowStatus
@@ -78,6 +79,22 @@ class FakeExecutor:
         }
 
 
+class RoutedFakeExecutor:
+    def __init__(self, proposals: dict[str, tuple[str, dict[str, object]]]) -> None:
+        self._proposals = proposals
+
+    async def propose(self, **kwargs):
+        expected_tool_name = str(kwargs.get('expected_tool_name') or '')
+        tool_name, tool_arguments = self._proposals[expected_tool_name]
+        return {
+            'action': 'tool',
+            'assistantMessage': f'Running {tool_name}',
+            'toolName': tool_name,
+            'toolArguments': tool_arguments,
+            'requiredInputs': [],
+        }
+
+
 class FakeInvalidExecutor:
     async def propose(self, **kwargs):
         del kwargs
@@ -87,6 +104,22 @@ class FakeInvalidExecutor:
             'toolName': None,
             'toolArguments': None,
             'requiredInputs': [],
+        }
+
+
+class FakeClarifyExecutor:
+    def __init__(self, required_inputs: list[str] | None = None, assistant_message: str | None = None) -> None:
+        self._required_inputs = required_inputs or []
+        self._assistant_message = assistant_message
+
+    async def propose(self, **kwargs):
+        del kwargs
+        return {
+            'action': 'clarify',
+            'assistantMessage': self._assistant_message,
+            'toolName': None,
+            'toolArguments': None,
+            'requiredInputs': self._required_inputs,
         }
 
 
@@ -115,6 +148,23 @@ class FakeReviewer:
         }
 
 
+class FakeClarifyReviewer:
+    def __init__(self, required_inputs: list[str] | None = None, assistant_message: str | None = None) -> None:
+        self._required_inputs = required_inputs or []
+        self._assistant_message = assistant_message
+
+    async def review(self, **kwargs):
+        del kwargs
+        return {
+            'action': 'clarify',
+            'assistantMessage': self._assistant_message,
+            'feedback': None,
+            'requiredInputs': self._required_inputs,
+            'includeTable': False,
+            'resolvedEntities': {},
+        }
+
+
 class FakeNarrator:
     async def write_message(self, **kwargs):
         fallback_message = kwargs.get('fallback_message')
@@ -123,6 +173,11 @@ class FakeNarrator:
         user_message = str(kwargs.get('user_message') or '').strip()
         if user_message:
             return f'Response to: {user_message}'
+        return str(kwargs.get('directive') or 'Done.')
+
+
+class FakeDirectiveNarrator:
+    async def write_message(self, **kwargs):
         return str(kwargs.get('directive') or 'Done.')
 
 
@@ -196,13 +251,30 @@ class FakeBackendClient:
         self.customer_payloads: list[dict[str, object]] = []
         self.customer_updates: list[tuple[str, dict[str, object]]] = []
         self.receipt_payloads: list[dict[str, object]] = []
-        self.products = [{'id': 'prod-1', 'name': 'Field Fresh Short'}]
+        self.products = [{'id': 'prod-1', 'name': 'Field Fresh Short', 'styleCode': 'FFS-001'}]
         self.product_detail = {
             'product': {'id': 'prod-1', 'base_price': 42},
             'skus': [{'id': 'sku-sand', 'color_name': 'Sand', 'price_override': None}],
             'sizes': [
                 {'id': 'size-sand-l', 'sku_id': 'sku-sand', 'size_label': 'L', 'price_override': None},
                 {'id': 'size-sand-m', 'sku_id': 'sku-sand', 'size_label': 'M', 'price_override': None},
+            ],
+        }
+        self.invoice_detail = {
+            'id': 'inv-1',
+            'lines': [
+                {
+                    'id': 'inv-line-1',
+                    'skuId': 'size-sand-m',
+                    'qty': 20,
+                    'unitPrice': 42,
+                },
+                {
+                    'id': 'inv-line-2',
+                    'skuId': 'size-sand-l',
+                    'qty': 10,
+                    'unitPrice': 42,
+                },
             ],
         }
 
@@ -244,11 +316,11 @@ class FakeBackendClient:
 
     async def create_po(self, *args, **kwargs):
         del args, kwargs
-        return {'ok': True}
+        return {'ok': True, 'id': 'po-1', 'poNumber': 'PO-001'}
 
     async def create_invoice(self, *args, **kwargs):
         del args, kwargs
-        return {'ok': True}
+        return {'ok': True, 'id': 'inv-1', 'invoiceNumber': 'SO-001'}
 
     async def create_product(self, *args, **kwargs):
         del args, kwargs
@@ -256,12 +328,12 @@ class FakeBackendClient:
 
     async def create_location(self, *args, **kwargs):
         del args, kwargs
-        return {'ok': True}
+        return {'ok': True, 'id': 'loc-created', 'name': 'Warehouse North'}
 
     async def create_customer(self, access_token: str, tenant_id: str | None, payload: dict[str, object]):
         del access_token, tenant_id
         self.customer_payloads.append(payload)
-        return {'ok': True, 'payload': payload}
+        return {'ok': True, 'id': 'cust-created', 'payload': payload}
 
     async def update_customer(
         self, access_token: str, tenant_id: str | None, customer_id: str, payload: dict[str, object]
@@ -297,16 +369,63 @@ class FakeBackendClient:
         del args, kwargs
         return []
 
+    async def list_pos(self, *args, **kwargs):
+        del args, kwargs
+        return {'items': [{'id': 'po-1', 'number': 'PO-001', 'supplierId': 'sup-1', 'supplierName': 'Acme Supply'}]}
+
+    async def list_invoices(self, *args, **kwargs):
+        del args, kwargs
+        return {'items': [{'id': 'inv-1', 'number': 'SO-001', 'customerId': 'cust-1', 'customerName': 'Helen Barrows'}]}
+
+    async def search_skus(self, access_token: str, tenant_id: str | None, q: str | None = None):
+        del access_token, tenant_id
+        if q and q.upper() != 'FFS-001':
+            return []
+        return [{'id': 'sku-sand', 'product_id': 'prod-1', 'sku_code': 'FFS-001'}]
+
     async def search_products(self, access_token: str, tenant_id: str | None, q: str | None = None, **kwargs):
         del access_token, tenant_id, kwargs
         if not q:
             return self.products
-        return [product for product in self.products if q.lower() in str(product['name']).lower()]
+        lowered = q.lower()
+        return [
+            product
+            for product in self.products
+            if lowered in str(product['name']).lower() or lowered in str(product.get('styleCode') or '').lower()
+        ]
 
     async def get_product(self, access_token: str, tenant_id: str | None, product_id: str):
         del access_token, tenant_id
         assert product_id == 'prod-1'
         return self.product_detail
+
+    async def get_po(self, access_token: str, tenant_id: str | None, po_id: str):
+        del access_token, tenant_id
+        assert po_id == 'po-1'
+        return {
+            'id': 'po-1',
+            'lines': [
+                {
+                    'skuId': 'size-sand-m',
+                    'sku': 'FFS-001-M',
+                    'qtyOrdered': 20,
+                    'qtyReceived': 0,
+                    'unitCost': 42,
+                },
+                {
+                    'skuId': 'size-sand-l',
+                    'sku': 'FFS-001-L',
+                    'qtyOrdered': 10,
+                    'qtyReceived': 0,
+                    'unitCost': 42,
+                },
+            ],
+        }
+
+    async def get_invoice(self, access_token: str, tenant_id: str | None, invoice_id: str):
+        del access_token, tenant_id
+        assert invoice_id == 'inv-1'
+        return self.invoice_detail
 
     async def evaluate_approval(self, *args, **kwargs):
         del args, kwargs
@@ -337,6 +456,74 @@ class FakeApprovalBackendClient(FakeBackendClient):
     async def evaluate_approval(self, *args, **kwargs):
         del args, kwargs
         return GovernanceEvaluationResponse(requires_approval=True, reason='Threshold exceeded')
+
+
+class FlakyReadBackendClient(FakeBackendClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.stock_attempts = 0
+
+    async def stock_on_hand(self, *args, **kwargs):
+        del args, kwargs
+        self.stock_attempts += 1
+        if self.stock_attempts == 1:
+            raise BackendValidationError(
+                status_code=400,
+                message='sizeId is required',
+                details=['lines.0.sizeId: required'],
+            )
+        return [{'sku_code': 'TSHIRT-BLACK', 'location_code': 'WH-LON', 'available': 12}]
+
+
+class EmptyResultsBackendClient(FakeBackendClient):
+    async def stock_on_hand(self, *args, **kwargs):
+        del args, kwargs
+        return []
+
+
+class ScopedLatestBackendClient(FakeBackendClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.invoices = [
+            {'id': 'inv-9', 'number': 'SO-0009', 'customerName': 'Alice Jones'},
+            {'id': 'inv-7', 'number': 'SO-0007', 'customerName': 'Bob Smith'},
+            {'id': 'inv-1', 'number': 'SO-0001', 'customerName': 'Bob Smith'},
+        ]
+        self.invoice_detail = {
+            'id': 'inv-7',
+            'lines': [
+                {
+                    'id': 'inv-line-1',
+                    'skuId': 'size-sand-m',
+                    'qty': 20,
+                    'unitPrice': 42,
+                },
+                {
+                    'id': 'inv-line-2',
+                    'skuId': 'size-sand-l',
+                    'qty': 10,
+                    'unitPrice': 42,
+                },
+            ],
+        }
+
+    async def get_invoice(self, access_token: str, tenant_id: str | None, invoice_id: str):
+        del access_token, tenant_id
+        assert invoice_id == 'inv-7'
+        return self.invoice_detail
+
+    async def list_invoices(self, *args, **kwargs):
+        del args, kwargs
+        return {'items': self.invoices}
+
+
+class FakeAuditService:
+    def __init__(self) -> None:
+        self.events: list[dict[str, object]] = []
+
+    async def record(self, **kwargs):
+        self.events.append(kwargs)
+        return kwargs
 
 
 def make_auth() -> AuthContext:
@@ -380,6 +567,136 @@ async def test_runtime_service_completes_read_flow():
     assert not any(block.type == BlockType.TABLE_RESULT for block in outcome.blocks)
 
 
+async def test_runtime_service_clarifies_invalid_read_tool_payload_before_backend_call():
+    backend = FakeBackendClient()
+    service = AgentRuntimeService(
+        backend_client=backend,  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('master.search_locations', {}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='show me warehouse locations',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.NEEDS_INPUT
+    assert any(block.type == BlockType.CLARIFICATION for block in outcome.blocks)
+    assert 'query' in outcome.missing_fields
+
+
+async def test_runtime_service_retries_after_backend_validation_error():
+    backend = FlakyReadBackendClient()
+    service = AgentRuntimeService(
+        backend_client=backend,  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'TSHIRT-BLACK'}),
+        reviewer=FakeReviewer(message='Stock is available in London.'),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='show stock for black t-shirt',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.COMPLETED
+    assert backend.stock_attempts == 2
+
+
+async def test_runtime_service_redirects_off_topic_requests():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'TSHIRT-BLACK'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'what is the size of the earth': {
+                    'useActiveWorkflow': False,
+                    'primaryRoute': 'read',
+                    'primaryIntent': 'off_topic',
+                    'confidence': 0.99,
+                    'rationale': 'Outside the supported inventory domain.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='what is the size of the earth',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.COMPLETED
+    assert 'inventory' in outcome.blocks[0].content.lower()
+
+
+async def test_runtime_service_returns_no_matches_without_narrator_hallucination():
+    service = AgentRuntimeService(
+        backend_client=EmptyResultsBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'TSHIRT-BLACK'}),
+        reviewer=FakeReviewer(message='This should be ignored.'),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='show stock for black t-shirt',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.COMPLETED
+    assert outcome.blocks[0].content == "I couldn't find any matches."
+
+
 async def test_runtime_service_includes_table_when_user_requests_full_details():
     events: list[tuple[str, dict[str, object]]] = []
     service = AgentRuntimeService(
@@ -408,6 +725,41 @@ async def test_runtime_service_includes_table_when_user_requests_full_details():
     assert outcome.status == WorkflowStatus.COMPLETED
     assert any(event_type == 'tool.called' for event_type, _payload in events)
     assert any(block.type == BlockType.TABLE_RESULT for block in outcome.blocks)
+
+
+async def test_runtime_service_records_tool_execution_audit_event():
+    audit = FakeAuditService()
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'TSHIRT-BLACK'}),
+        reviewer=FakeReviewer(message='Stock is available in London.'),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        audit_service=audit,  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    conversation_id = uuid4()
+    workflow_id = uuid4()
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=conversation_id,
+        workflow_id=workflow_id,
+        user_message='show stock for black t-shirt',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.COMPLETED
+    assert audit.events[0]['event_type'] == 'tool_executed'
+    assert audit.events[0]['conversation_id'] == str(conversation_id)
+    assert audit.events[0]['workflow_id'] == str(workflow_id)
+    assert audit.events[0]['tool_name'] == 'inventory.stock_on_hand'
 
 
 async def test_runtime_service_requests_approval_for_high_risk_writes():
@@ -485,6 +837,163 @@ async def test_runtime_service_requests_approval_for_customer_create():
         'email': 'helen41@yahoo.com',
     }
     assert not any(event_type == 'approval.requested' for event_type, _payload in events)
+
+
+async def test_runtime_service_starts_fresh_contact_workflow_when_intent_changes():
+    service = AgentRuntimeService(
+        backend_client=FakeApprovalBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor(
+            'master.create_customer',
+            {
+                'name': 'Aibuyer',
+                'email': 'aibuyer@gmail.com',
+            },
+        ),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'create a customer named Aibuyer with email aibuyer@gmail.com': {
+                    'useActiveWorkflow': False,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'master.create_customer',
+                    'confidence': 0.97,
+                    'rationale': 'The user started a new customer creation request.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='create a customer named Aibuyer with email aibuyer@gmail.com',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'master.create_supplier',
+            'executionPayload': {
+                'name': 'aiseller',
+                'email': 'aisell@sell.com',
+                'address': 'london',
+            },
+            'activeApprovalId': str(uuid4()),
+            'activeApprovalStatus': 'pending',
+            'basePrice': 25,
+            'styleCode': 'ai-0033',
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'master.create_supplier',
+                'entities': {
+                    'name': 'aiseller',
+                    'email': 'aisell@sell.com',
+                    'address': 'london',
+                    'basePrice': 25,
+                    'styleCode': 'ai-0033',
+                },
+                'missingFields': [],
+                'postActions': [],
+                'clarificationCount': 0,
+                'status': 'awaiting_approval',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.AWAITING_APPROVAL,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload'] == {
+        'name': 'Aibuyer',
+        'email': 'aibuyer@gmail.com',
+    }
+    assert outcome.extracted_entities['preview']['preparedArguments'] == {
+        'name': 'Aibuyer',
+        'email': 'aibuyer@gmail.com',
+    }
+    assert outcome.extracted_entities['activeApprovalId'] is None
+    assert outcome.extracted_entities['_approvalOperation'] == 'create_new'
+    assert 'basePrice' not in outcome.extracted_entities['taskContext']['entities']
+    assert 'styleCode' not in outcome.extracted_entities['taskContext']['entities']
+
+
+async def test_runtime_service_keeps_existing_contact_name_when_user_confirms_reuse_with_yes():
+    service = AgentRuntimeService(
+        backend_client=FakeApprovalBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor(
+            'master.create_supplier',
+            {
+                'name': 'aiseller',
+                'email': 'aisell@sell.com',
+                'address': 'london',
+            },
+        ),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'yes': {
+                    'useActiveWorkflow': True,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'master.create_supplier',
+                    'confidence': 0.96,
+                    'rationale': 'The user confirmed that the existing supplier details should be reused.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='yes',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'master.create_supplier',
+            'executionPayload': {
+                'name': 'aiseller',
+                'email': 'aisell@sell.com',
+                'address': 'london',
+            },
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'master.create_supplier',
+                'entities': {
+                    'name': 'aiseller',
+                    'email': 'aisell@sell.com',
+                    'address': 'london',
+                },
+                'missingFields': ['name'],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload']['name'] == 'aiseller'
+    assert outcome.extracted_entities['preview']['preparedArguments']['name'] == 'aiseller'
 
 
 async def test_runtime_service_handles_trace_attempts_without_crashing():
@@ -691,6 +1200,82 @@ async def test_runtime_service_clarifies_missing_required_fields_before_confirma
     assert outcome.status == WorkflowStatus.NEEDS_INPUT
     assert any(block.type == BlockType.CLARIFICATION for block in outcome.blocks)
     assert 'color_name' in outcome.missing_fields
+
+
+async def test_runtime_service_confirmation_preview_uses_authenticated_actor():
+    service = AgentRuntimeService(
+        backend_client=FakeApprovalBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor(
+            'master.create_customer',
+            {'name': 'Helen Fields', 'email': 'helen@example.com'},
+        ),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='create customer Helen Fields',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    preview_blocks = [block for block in outcome.blocks if block.type == BlockType.PREVIEW]
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert preview_blocks[0].actor == 'ops@example.com'
+
+
+async def test_runtime_service_warns_before_confirming_duplicate_purchase_order():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor(
+            'purchasing.create_po',
+            {
+                'supplierId': 'sup-1',
+                'lines': [
+                    {'sizeId': 'size-sand-m', 'qty': 20, 'unitCost': 42},
+                    {'sizeId': 'size-sand-l', 'qty': 10, 'unitCost': 42},
+                ],
+            },
+        ),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='create the same purchase order again',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    preview_blocks = [block for block in outcome.blocks if block.type == BlockType.PREVIEW]
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert preview_blocks
+    assert preview_blocks[0].warnings == [
+        'Possible duplicate purchase order: PO-001 already has the same supplier and line items.'
+    ]
+    assert outcome.extracted_entities['preview']['warnings'] == [
+        'Possible duplicate purchase order: PO-001 already has the same supplier and line items.'
+    ]
 
 
 async def test_runtime_service_clarifies_missing_customer_name_before_confirmation():
@@ -917,6 +1502,205 @@ async def test_runtime_service_applies_location_clarification_reply_without_repl
     assert any(block.type == BlockType.CONFIRMATION_REQUIRED for block in outcome.blocks)
 
 
+async def test_runtime_service_applies_po_clarification_reply_with_product_price_lookup():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'TSHIRT-BLACK'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='get it from the products',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'purchasing.create_po',
+            'executionPayload': {
+                'supplierId': 'Acme Supply',
+                'lines': [
+                    {
+                        'productName': 'Field Fresh Short',
+                        'colorName': 'Sand',
+                        'sizeLabel': 'L',
+                        'quantity': 5,
+                    }
+                ],
+            },
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'purchasing.create_po',
+                'entities': {
+                    'supplierId': 'Acme Supply',
+                    'lines': [
+                        {
+                            'productName': 'Field Fresh Short',
+                            'colorName': 'Sand',
+                            'sizeLabel': 'L',
+                            'quantity': 5,
+                        }
+                    ],
+                },
+                'missingFields': [],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload']['supplierId'] == 'sup-1'
+    assert outcome.extracted_entities['executionPayload']['lines'] == [
+        {'sizeId': 'size-sand-l', 'qty': 5, 'unitCost': 42}
+    ]
+    assert any(block.type == BlockType.CONFIRMATION_REQUIRED for block in outcome.blocks)
+
+
+async def test_runtime_service_edits_pending_po_in_awaiting_approval_and_requests_variant_selection():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'TSHIRT-BLACK'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='FFS-001\n20 items',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'purchasing.create_po',
+            'executionPayload': {
+                'supplierId': 'Acme Supply',
+                'lines': [
+                    {
+                        'productName': 'Field Fresh Short',
+                        'colorName': 'Sand',
+                        'sizeLabel': 'L',
+                        'quantity': 10,
+                    }
+                ],
+            },
+            'activeApprovalId': str(uuid4()),
+            'activeApprovalStatus': 'pending',
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'purchasing.create_po',
+                'entities': {
+                    'supplierId': 'Acme Supply',
+                    'lines': [
+                        {
+                            'productName': 'Field Fresh Short',
+                            'colorName': 'Sand',
+                            'sizeLabel': 'L',
+                            'quantity': 10,
+                        }
+                    ],
+                },
+                'missingFields': [],
+                'postActions': [],
+                'clarificationCount': 0,
+                'status': 'awaiting_approval',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.AWAITING_APPROVAL,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.NEEDS_INPUT
+    assert any(block.type == BlockType.CLARIFICATION for block in outcome.blocks)
+    assert 'Which variant should I use?' in outcome.blocks[0].prompt
+    assert 'Sand / L' in outcome.blocks[0].prompt
+    assert outcome.extracted_entities['toolName'] == 'purchasing.create_po'
+
+
+async def test_runtime_service_clarification_reply_preserves_latest_po_lines_over_stale_task_context():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'TSHIRT-BLACK'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='use the same supplier',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'purchasing.create_po',
+            'executionPayload': {
+                'lines': [
+                    {
+                        'productName': 'Field Fresh Short',
+                        'colorName': 'Sand',
+                        'sizeLabel': 'M',
+                        'quantity': 20,
+                    }
+                ],
+            },
+                'taskContext': {
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'purchasing.create_po',
+                    'entities': {
+                        'supplierId': 'Acme Supply',
+                    'lines': [
+                        {
+                            'productName': 'Field Fresh Short',
+                            'colorName': 'Sand',
+                            'sizeLabel': 'L',
+                            'quantity': 10,
+                        }
+                    ],
+                },
+                'missingFields': ['supplier_id'],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            },
+            'missingFields': ['supplier_id'],
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload']['supplierId'] == 'sup-1'
+    assert outcome.extracted_entities['executionPayload']['lines'] == [
+        {'sizeId': 'size-sand-m', 'qty': 20, 'unitCost': 42}
+    ]
+    assert any(block.type == BlockType.CONFIRMATION_REQUIRED for block in outcome.blocks)
+
+
 async def test_runtime_service_reuses_completed_read_context_for_this_follow_up():
     service = AgentRuntimeService(
         backend_client=FakeBackendClient(),  # type: ignore[arg-type]
@@ -1056,6 +1840,1482 @@ async def test_runtime_service_invalid_executor_proposal_requests_clarification(
     assert outcome.status == WorkflowStatus.NEEDS_INPUT
     assert outcome.missing_fields == ['customer_id', 'lines']
     assert any(block.type == BlockType.CLARIFICATION for block in outcome.blocks)
+    assert outcome.extracted_entities['pendingTask']['intent'] == 'sales.create_invoice'
+    assert outcome.extracted_entities['pendingTask']['missingFields'] == ['customer_id', 'lines']
+
+
+async def test_runtime_service_planner_clarification_uses_intent_specific_prompt():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(action='clarify'),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'TSHIRT-BLACK'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeDirectiveNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'dispatch sales order': {
+                    'useActiveWorkflow': False,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'sales.dispatch_invoice',
+                    'confidence': 0.95,
+                    'rationale': 'Dispatch request detected.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='dispatch sales order',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.NEEDS_INPUT
+    assert outcome.blocks[0].prompt == 'Which sales order should I dispatch, and from which location?'
+    assert outcome.missing_fields == ['sales_order_id', 'location_id']
+
+
+async def test_runtime_service_executor_clarification_uses_intent_specific_prompt():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeClarifyExecutor(),  # type: ignore[arg-type]
+        reviewer=FakeReviewer(),
+        narrator=FakeDirectiveNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'receive purchase order': {
+                    'useActiveWorkflow': False,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'purchasing.receive_po',
+                    'confidence': 0.95,
+                    'rationale': 'Receipt request detected.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='receive purchase order',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.NEEDS_INPUT
+    assert outcome.blocks[0].prompt == 'Which purchase order should I receive, and which location should it go to?'
+    assert outcome.missing_fields == ['po_id', 'location_id']
+
+
+async def test_runtime_service_reviewer_clarification_uses_intent_specific_prompt():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'TSHIRT-BLACK'}),
+        reviewer=FakeClarifyReviewer(assistant_message='Please clarify your request.'),  # type: ignore[arg-type]
+        narrator=FakeDirectiveNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'create purchase order': {
+                    'useActiveWorkflow': False,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'purchasing.create_po',
+                    'confidence': 0.95,
+                    'rationale': 'PO creation request detected.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='create purchase order',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.NEEDS_INPUT
+    assert (
+        outcome.blocks[0].prompt
+        == 'Reply with the supplier name and PO lines in the format `SKUCODE/SIZE xQTY @UNIT_COST`, separated by commas.'
+    )
+    assert outcome.missing_fields == ['supplier_id', 'lines']
+
+
+async def test_runtime_service_missing_resolved_write_reference_requests_clarification():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('sales.cancel_invoice', {}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'cancel it': {
+                    'useActiveWorkflow': False,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'sales.cancel_invoice',
+                    'confidence': 0.95,
+                    'rationale': 'Detected a sales order cancellation request.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='cancel it',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.NEEDS_INPUT
+    assert outcome.missing_fields == ['sales_order_id']
+    assert any(block.type == BlockType.CLARIFICATION for block in outcome.blocks)
+    assert outcome.extracted_entities['pendingTask']['intent'] == 'sales.cancel_invoice'
+
+
+async def test_runtime_service_recovers_update_last_po_from_sparse_executor_proposal():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeInvalidExecutor(),  # type: ignore[arg-type]
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'update my last PO expected date to 2026-05-30': {
+                    'useActiveWorkflow': False,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'purchasing.update_po',
+                    'confidence': 0.96,
+                    'rationale': 'Update request detected.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='update my last PO expected date to 2026-05-30',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['toolName'] == 'purchasing.update_po'
+    assert outcome.extracted_entities['executionPayload'] == {
+        'poId': 'po-1',
+        'headerPatch': {'expectedDate': '2026-05-30'},
+    }
+
+
+async def test_runtime_service_recovers_update_last_po_remove_second_line_from_sparse_executor_proposal():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeInvalidExecutor(),  # type: ignore[arg-type]
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'update my last PO by removing the second line': {
+                    'useActiveWorkflow': False,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'purchasing.update_po',
+                    'confidence': 0.96,
+                    'rationale': 'Update request detected.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='update my last PO by removing the second line',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['toolName'] == 'purchasing.update_po'
+    assert outcome.extracted_entities['executionPayload'] == {
+        'poId': 'po-1',
+        'lineOps': [
+            {
+                'op': 'remove',
+                'lineRef': {'sizeId': 'size-sand-l'},
+            }
+        ],
+    }
+
+
+async def test_runtime_service_recovers_update_last_sales_order_medium_line_quantity_from_sparse_executor_proposal():
+    service = AgentRuntimeService(
+        backend_client=ScopedLatestBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeInvalidExecutor(),  # type: ignore[arg-type]
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'update the last sales order for Bob Smith by changing the medium line quantity to 11': {
+                    'useActiveWorkflow': False,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'sales.update_invoice',
+                    'confidence': 0.96,
+                    'rationale': 'Sales update request detected.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='update the last sales order for Bob Smith by changing the medium line quantity to 11',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['toolName'] == 'sales.update_invoice'
+    assert outcome.extracted_entities['executionPayload'] == {
+        'invoiceId': 'inv-7',
+        'lineOps': [
+            {
+                'op': 'change_qty',
+                'lineRef': {'lineId': 'inv-line-1'},
+                'qty': 11,
+            }
+        ],
+    }
+
+
+async def test_runtime_service_recovers_cancel_last_sales_order_for_customer_from_sparse_executor_proposal():
+    service = AgentRuntimeService(
+        backend_client=ScopedLatestBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeInvalidExecutor(),  # type: ignore[arg-type]
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'cancel the last sales order for Bob Smith': {
+                    'useActiveWorkflow': False,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'sales.cancel_invoice',
+                    'confidence': 0.96,
+                    'rationale': 'Sales cancellation request detected.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='cancel the last sales order for Bob Smith',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['toolName'] == 'sales.cancel_invoice'
+    assert outcome.extracted_entities['executionPayload'] == {
+        'invoiceId': 'inv-7',
+        'confirm': True,
+    }
+
+
+async def test_runtime_service_recovers_dispatch_last_sales_order_from_sparse_executor_proposal():
+    service = AgentRuntimeService(
+        backend_client=ScopedLatestBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeInvalidExecutor(),  # type: ignore[arg-type]
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'dispatch the last sales order for Bob Smith from Warehouse A': {
+                    'useActiveWorkflow': False,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'sales.dispatch_invoice',
+                    'confidence': 0.96,
+                    'rationale': 'Sales dispatch request detected.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='dispatch the last sales order for Bob Smith from Warehouse A',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['toolName'] == 'sales.dispatch_invoice'
+    assert outcome.extracted_entities['executionPayload'] == {
+        'invoiceId': 'inv-7',
+        'locationId': LOCATION_A,
+        'confirm': True,
+    }
+
+
+async def test_runtime_service_recovers_receive_last_po_from_sparse_executor_proposal():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeInvalidExecutor(),  # type: ignore[arg-type]
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'receive my last PO at Warehouse A': {
+                    'useActiveWorkflow': False,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'purchasing.receive_po',
+                    'confidence': 0.96,
+                    'rationale': 'PO receipt request detected.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='receive my last PO at Warehouse A',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['toolName'] == 'purchasing.receive_po'
+    assert outcome.extracted_entities['executionPayload'] == {
+        'poId': 'po-1',
+        'locationId': LOCATION_A,
+        'lines': [
+            {'sizeId': 'size-sand-m', 'qty': 20, 'unitCost': 42},
+            {'sizeId': 'size-sand-l', 'qty': 10, 'unitCost': 42},
+        ],
+        'confirm': True,
+    }
+
+
+async def test_runtime_service_recovers_get_last_po_from_sparse_executor_proposal():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeInvalidExecutor(),  # type: ignore[arg-type]
+        reviewer=FakeReviewer(message='PO status is draft.'),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'what is the status of my last PO': {
+                    'useActiveWorkflow': False,
+                    'primaryRoute': 'read',
+                    'primaryIntent': 'purchasing.get_po',
+                    'confidence': 0.96,
+                    'rationale': 'PO status request detected.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='what is the status of my last PO',
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.COMPLETED
+    assert any(block.type == BlockType.TEXT for block in outcome.blocks)
+
+
+def test_runtime_service_sanitizes_write_arguments_from_task_context_entities():
+    tool_arguments = AgentRuntimeService._sanitize_tool_arguments(
+        tool_name='sales.dispatch_invoice',
+        tool_arguments={'invoiceId': 'it', 'locationId': 'there'},
+        current_entities={
+            'taskContext': {
+                'entities': {
+                    'invoiceId': 'inv-1',
+                    'locationId': LOCATION_A,
+                }
+            }
+        },
+    )
+
+    assert tool_arguments == {
+        'invoiceId': 'inv-1',
+        'locationId': LOCATION_A,
+    }
+
+
+def test_runtime_service_merges_created_invoice_identity_into_context():
+    merged = AgentRuntimeService._merge_context_from_tool_interaction(
+        current_entities={
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'sales.create_invoice',
+                'entities': {
+                    'customerId': 'cust-1',
+                    'customerName': 'Northwind Stores',
+                },
+            }
+        },
+        tool_name='sales.create_invoice',
+        tool_arguments={'customerId': 'cust-1', 'lines': [{'sizeId': SIZE_1, 'qty': 2, 'unitPrice': 18}]},
+        tool_result={'result': {'id': 'inv-1', 'invoiceNumber': 'SO-001'}},
+    )
+
+    task_entities = merged['taskContext']['entities']
+    assert task_entities['invoiceId'] == 'inv-1'
+    assert task_entities['invoiceNumber'] == 'SO-001'
+    assert merged['invoiceId'] == 'inv-1'
+    assert merged['invoiceNumber'] == 'SO-001'
+
+
+def test_runtime_service_merges_created_po_supplier_identity_into_context():
+    merged = AgentRuntimeService._merge_context_from_tool_interaction(
+        current_entities={
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'purchasing.create_po',
+                'entities': {},
+            }
+        },
+        tool_name='purchasing.create_po',
+        tool_arguments={'supplierId': 'sup-1', 'lines': [{'sizeId': SIZE_1, 'qty': 2, 'unitCost': 18}]},
+        tool_result={'result': {'id': 'po-1', 'poNumber': 'PO-001'}},
+    )
+
+    task_entities = merged['taskContext']['entities']
+    assert task_entities['supplierId'] == 'sup-1'
+    assert task_entities['poId'] == 'po-1'
+    assert task_entities['poNumber'] == 'PO-001'
+    assert merged['supplierId'] == 'sup-1'
+    assert merged['poId'] == 'po-1'
+    assert merged['poNumber'] == 'PO-001'
+
+
+async def test_runtime_service_reuses_completed_po_supplier_for_new_po_follow_up():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor(
+            'purchasing.create_po',
+            {
+                'lines': [
+                    {
+                        'productName': 'Field Fresh Short',
+                        'colorName': 'Sand',
+                        'sizeLabel': 'M',
+                        'quantity': 7,
+                        'unitCost': 18,
+                    }
+                ]
+            },
+        ),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'create another purchase order with Sand M x7 @18': {
+                    'useActiveWorkflow': True,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'purchasing.create_po',
+                    'confidence': 0.95,
+                    'rationale': 'Reuse the active supplier for a new purchase order.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='create another purchase order with Sand M x7 @18',
+        extracted_entities={
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'purchasing.create_po',
+                'entities': {
+                    'supplierId': 'sup-1',
+                    'poId': 'po-1',
+                    'poNumber': 'PO-001',
+                },
+                'missingFields': [],
+                'postActions': [],
+                'clarificationCount': 0,
+                'status': 'completed',
+            }
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.COMPLETED,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload']['supplierId'] == 'sup-1'
+    assert outcome.extracted_entities['executionPayload']['lines'] == [
+        {'sizeId': 'size-sand-m', 'qty': 7, 'unitCost': 18}
+    ]
+
+
+async def test_runtime_service_splits_compound_commerce_message_into_confirmation_queue():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=RoutedFakeExecutor(
+            {
+                'master.create_supplier': (
+                    'master.create_supplier',
+                    {
+                        'name': 'Fashion Hub',
+                        'phone': '020-123-4567',
+                        'address': '10 Avenue',
+                    },
+                ),
+            }
+        ),  # type: ignore[arg-type]
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'create supplier Fashion Hub phone 020-123-4567 address 10 Avenue': {
+                    'useActiveWorkflow': False,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'master.create_supplier',
+                    'confidence': 0.98,
+                    'rationale': 'The first clause creates a supplier.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message=(
+            'create supplier Fashion Hub phone 020-123-4567 address 10 Avenue, '
+            'then create PO for Classic Shirt Red S x20 @18, and update my last PO expected date to 2026-05-30'
+        ),
+        extracted_entities={},
+        recent_messages=[],
+        workflow_status=WorkflowStatus.IDLE,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['toolName'] == 'master.create_supplier'
+    assert outcome.extracted_entities['compoundQueue'] == [
+        'create PO for Classic Shirt Red S x20 @18',
+        'update my last PO expected date to 2026-05-30',
+    ]
+
+
+async def test_runtime_service_reuses_completed_sales_order_for_dispatch_follow_up():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor(
+            'sales.dispatch_invoice',
+            {
+                'locationId': 'Warehouse A',
+            },
+        ),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'dispatch that sales order from Warehouse A': {
+                    'useActiveWorkflow': True,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'sales.dispatch_invoice',
+                    'confidence': 0.95,
+                    'rationale': 'Dispatch the active sales order from the requested location.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='dispatch that sales order from Warehouse A',
+        extracted_entities={
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'sales.create_invoice',
+                'entities': {
+                    'invoiceId': 'inv-1',
+                    'invoiceNumber': 'SO-001',
+                    'customerId': 'cust-1',
+                },
+                'missingFields': [],
+                'postActions': [],
+                'clarificationCount': 0,
+                'status': 'completed',
+            }
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.COMPLETED,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload']['invoiceId'] == 'inv-1'
+    assert outcome.extracted_entities['executionPayload']['locationId'] == LOCATION_A
+
+
+async def test_runtime_service_applies_po_update_clarification_reply_without_replanning():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'unused'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'change expected date to 2026-06-10 and quantity of MT-BLK/SM to 120': {
+                    'useActiveWorkflow': True,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'purchasing.update_po',
+                    'confidence': 0.96,
+                    'rationale': 'The user is clarifying the active PO update draft.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='change expected date to 2026-06-10 and quantity of MT-BLK/SM to 120',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'purchasing.update_po',
+            'executionPayload': {'poId': 'po-1'},
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'purchasing.update_po',
+                'entities': {'poId': 'po-1', 'poNumber': 'PO-001'},
+                'missingFields': ['patch'],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload'] == {
+        'poId': 'po-1',
+        'headerPatch': {'expectedDate': '2026-06-10'},
+        'lineOps': [
+            {
+                'op': 'change_qty',
+                'lineRef': {'skuCode': 'MT-BLK', 'sizeLabel': 'SM'},
+                'qty': 120,
+            }
+        ],
+    }
+
+
+async def test_runtime_service_applies_sales_update_clarification_reply_without_replanning():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'unused'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'change quantity of HOOD-ECO/MD to 15': {
+                    'useActiveWorkflow': True,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'sales.update_invoice',
+                    'confidence': 0.96,
+                    'rationale': 'The user is clarifying the active sales-order update draft.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='change quantity of HOOD-ECO/MD to 15',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'sales.update_invoice',
+            'executionPayload': {'invoiceId': 'inv-1'},
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'sales.update_invoice',
+                'entities': {'invoiceId': 'inv-1', 'invoiceNumber': 'SO-001'},
+                'missingFields': ['patch'],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload'] == {
+        'invoiceId': 'inv-1',
+        'lineOps': [
+            {
+                'op': 'change_qty',
+                'lineRef': {'skuCode': 'HOOD-ECO', 'sizeLabel': 'MD'},
+                'qty': 15,
+            }
+        ],
+    }
+
+
+async def test_runtime_service_applies_po_update_ordinal_quantity_change_without_replanning():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'unused'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'change the second line quantity to 12': {
+                    'useActiveWorkflow': True,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'purchasing.update_po',
+                    'confidence': 0.96,
+                    'rationale': 'The user is clarifying a specific PO line update.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='change the second line quantity to 12',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'purchasing.update_po',
+            'executionPayload': {'poId': 'po-1'},
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'purchasing.update_po',
+                'entities': {'poId': 'po-1', 'poNumber': 'PO-001'},
+                'missingFields': ['patch'],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload'] == {
+        'poId': 'po-1',
+        'lineOps': [
+            {
+                'op': 'change_qty',
+                'lineRef': {'sizeId': 'size-sand-l'},
+                'qty': 12,
+            }
+        ],
+    }
+
+
+async def test_runtime_service_applies_po_update_remove_line_without_replanning():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'unused'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'remove the second line': {
+                    'useActiveWorkflow': True,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'purchasing.update_po',
+                    'confidence': 0.96,
+                    'rationale': 'The user is removing a specific PO line.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='remove the second line',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'purchasing.update_po',
+            'executionPayload': {'poId': 'po-1'},
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'purchasing.update_po',
+                'entities': {'poId': 'po-1', 'poNumber': 'PO-001'},
+                'missingFields': ['patch'],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload'] == {
+        'poId': 'po-1',
+        'lineOps': [
+            {
+                'op': 'remove',
+                'lineRef': {'sizeId': 'size-sand-l'},
+            }
+        ],
+    }
+
+
+async def test_runtime_service_applies_po_update_remove_medium_line_without_replanning():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'unused'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'remove the medium line': {
+                    'useActiveWorkflow': True,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'purchasing.update_po',
+                    'confidence': 0.96,
+                    'rationale': 'The user is removing a PO line by size label.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='remove the medium line',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'purchasing.update_po',
+            'executionPayload': {'poId': 'po-1'},
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'purchasing.update_po',
+                'entities': {'poId': 'po-1', 'poNumber': 'PO-001'},
+                'missingFields': ['patch'],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload'] == {
+        'poId': 'po-1',
+        'lineOps': [
+            {
+                'op': 'remove',
+                'lineRef': {'sizeId': 'size-sand-m'},
+            }
+        ],
+    }
+
+
+async def test_runtime_service_applies_sales_update_remove_line_without_replanning():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'unused'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'remove the second line': {
+                    'useActiveWorkflow': True,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'sales.update_invoice',
+                    'confidence': 0.96,
+                    'rationale': 'The user is removing a specific sales-order line.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='remove the second line',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'sales.update_invoice',
+            'executionPayload': {'invoiceId': 'inv-1'},
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'sales.update_invoice',
+                'entities': {'invoiceId': 'inv-1', 'invoiceNumber': 'SO-001'},
+                'missingFields': ['patch'],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload'] == {
+        'invoiceId': 'inv-1',
+        'lineOps': [
+            {
+                'op': 'remove',
+                'lineRef': {'lineId': 'inv-line-2'},
+            }
+        ],
+    }
+
+
+async def test_runtime_service_applies_sales_update_change_medium_line_quantity_without_replanning():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'unused'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'change the medium line quantity to 11': {
+                    'useActiveWorkflow': True,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'sales.update_invoice',
+                    'confidence': 0.96,
+                    'rationale': 'The user is changing a sales-order line by size label.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='change the medium line quantity to 11',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'sales.update_invoice',
+            'executionPayload': {'invoiceId': 'inv-1'},
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'sales.update_invoice',
+                'entities': {'invoiceId': 'inv-1', 'invoiceNumber': 'SO-001'},
+                'missingFields': ['patch'],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload'] == {
+        'invoiceId': 'inv-1',
+        'lineOps': [
+            {
+                'op': 'change_qty',
+                'lineRef': {'lineId': 'inv-line-1'},
+                'qty': 11,
+            }
+        ],
+    }
+
+
+async def test_runtime_service_applies_po_update_add_line_clarification_reply_without_replanning():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'unused'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'add another line FFS-001/M x4 @20': {
+                    'useActiveWorkflow': True,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'purchasing.update_po',
+                    'confidence': 0.96,
+                    'rationale': 'The user is adding a new line to the active PO update draft.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='add another line FFS-001/M x4 @20',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'purchasing.update_po',
+            'executionPayload': {'poId': 'po-1'},
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'purchasing.update_po',
+                'entities': {'poId': 'po-1', 'poNumber': 'PO-001'},
+                'missingFields': ['patch'],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload'] == {
+        'poId': 'po-1',
+        'lineOps': [
+            {
+                'op': 'add',
+                'values': {'sizeId': 'size-sand-m', 'qty': 4, 'unitCost': 20},
+            }
+        ],
+    }
+
+
+async def test_runtime_service_applies_receive_po_clarification_reply_without_replanning():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'unused'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'receive at Warehouse A FFS-001/M x5': {
+                    'useActiveWorkflow': True,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'purchasing.receive_po',
+                    'confidence': 0.96,
+                    'rationale': 'The user supplied the missing receipt location and lines.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='receive at Warehouse A FFS-001/M x5',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'purchasing.receive_po',
+            'executionPayload': {'poId': 'po-1'},
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'purchasing.receive_po',
+                'entities': {'poId': 'po-1', 'poNumber': 'PO-001'},
+                'missingFields': ['location_id', 'lines'],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload']['poId'] == 'po-1'
+    assert outcome.extracted_entities['executionPayload']['poNumber'] == 'PO-001'
+    assert outcome.extracted_entities['executionPayload']['locationId'] == LOCATION_A
+    assert outcome.extracted_entities['executionPayload']['lines'] == [
+        {'sizeId': 'size-sand-m', 'qty': 5, 'unitCost': 42}
+    ]
+    assert outcome.extracted_entities['executionPayload']['confirm'] is True
+
+
+async def test_runtime_service_applies_dispatch_clarification_reply_without_replanning():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'unused'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'from Warehouse A': {
+                    'useActiveWorkflow': True,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'sales.dispatch_invoice',
+                    'confidence': 0.96,
+                    'rationale': 'The user supplied the missing dispatch location.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='from Warehouse A',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'sales.dispatch_invoice',
+            'executionPayload': {'invoiceId': 'inv-1'},
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'sales.dispatch_invoice',
+                'entities': {'invoiceId': 'inv-1', 'invoiceNumber': 'SO-001'},
+                'missingFields': ['location_id'],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload'] == {
+        'invoiceId': 'inv-1',
+        'locationId': LOCATION_A,
+        'confirm': True,
+    }
+
+
+async def test_runtime_service_uses_pending_task_for_short_alias_follow_up():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('products.create_product', {}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'FFS-001': {
+                    'useActiveWorkflow': False,
+                    'primaryRoute': 'read',
+                    'primaryIntent': 'inventory.stock_on_hand',
+                    'confidence': 0.35,
+                    'rationale': 'Recovered a style code value.',
+                    'entityPatches': {'styleCode': 'FFS-001'},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    extracted_entities = {
+        '_workflowEngine': 'runtime',
+        'toolName': 'products.create_product',
+        'executionPayload': {
+            'product': {
+                'name': 'Field Fresh Short',
+                'basePrice': 100,
+            },
+            'variants': [
+                {
+                    'colorName': 'Sand',
+                    'sizes': [{'sizeLabel': 'M'}],
+                }
+            ],
+        },
+        'taskContext': {
+            'primaryRoute': 'mutation',
+            'primaryIntent': 'products.create_product',
+            'entities': {
+                'name': 'Field Fresh Short',
+                'basePrice': 100,
+                'colorName': 'Sand',
+                'sizeLabels': ['M'],
+            },
+            'missingFields': ['style_code'],
+            'postActions': [],
+            'clarificationCount': 0,
+            'status': 'drafting',
+        },
+    }
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='FFS-001',
+        extracted_entities=extracted_entities,
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload']['product']['styleCode'] == 'FFS-001'
 
 
 async def test_runtime_service_handles_small_talk_without_tool_planning():

--- a/conversational-engine/tests/test_runtime_service.py
+++ b/conversational-engine/tests/test_runtime_service.py
@@ -517,6 +517,36 @@ class ScopedLatestBackendClient(FakeBackendClient):
         return {'items': self.invoices}
 
 
+class HarborVariantBackendClient(FakeBackendClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.products = [{'id': 'prod-harbor', 'name': 'Harbor Intelligent Parka', 'styleCode': 'STK-0013'}]
+        self.product_detail = {
+            'product': {'id': 'prod-harbor', 'base_price': 55},
+            'skus': [
+                {'id': 'sku-sand', 'color_name': 'Sand', 'price_override': None},
+                {'id': 'sku-navy', 'color_name': 'Navy', 'price_override': None},
+            ],
+            'sizes': [
+                {'id': 'size-sand-xs', 'sku_id': 'sku-sand', 'size_label': 'XS', 'price_override': None},
+                {'id': 'size-sand-s', 'sku_id': 'sku-sand', 'size_label': 'S', 'price_override': None},
+                {'id': 'size-sand-m', 'sku_id': 'sku-sand', 'size_label': 'M', 'price_override': None},
+                {'id': 'size-sand-l', 'sku_id': 'sku-sand', 'size_label': 'L', 'price_override': None},
+                {'id': 'size-sand-xl', 'sku_id': 'sku-sand', 'size_label': 'XL', 'price_override': None},
+                {'id': 'size-navy-xs', 'sku_id': 'sku-navy', 'size_label': 'XS', 'price_override': None},
+                {'id': 'size-navy-s', 'sku_id': 'sku-navy', 'size_label': 'S', 'price_override': None},
+                {'id': 'size-navy-m', 'sku_id': 'sku-navy', 'size_label': 'M', 'price_override': None},
+                {'id': 'size-navy-l', 'sku_id': 'sku-navy', 'size_label': 'L', 'price_override': None},
+                {'id': 'size-navy-xl', 'sku_id': 'sku-navy', 'size_label': 'XL', 'price_override': None},
+            ],
+        }
+
+    async def get_product(self, access_token: str, tenant_id: str | None, product_id: str):
+        del access_token, tenant_id
+        assert product_id == 'prod-harbor'
+        return self.product_detail
+
+
 class FakeAuditService:
     def __init__(self) -> None:
         self.events: list[dict[str, object]] = []
@@ -994,6 +1024,78 @@ async def test_runtime_service_keeps_existing_contact_name_when_user_confirms_re
     assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
     assert outcome.extracted_entities['executionPayload']['name'] == 'aiseller'
     assert outcome.extracted_entities['preview']['preparedArguments']['name'] == 'aiseller'
+
+
+async def test_runtime_service_updates_supplier_confirmation_draft_with_phone_and_address():
+    service = AgentRuntimeService(
+        backend_client=FakeApprovalBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor(
+            'master.create_supplier',
+            {
+                'name': 'Eagle Fabrics',
+                'email': 'eagle@example.com',
+            },
+        ),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'Phone is 020-765-4321, address 45 Textile Lane, Liverpool.': {
+                    'useActiveWorkflow': True,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'master.create_supplier',
+                    'confidence': 0.97,
+                    'rationale': 'The user is filling missing contact fields on the active supplier draft.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='Phone is 020-765-4321, address 45 Textile Lane, Liverpool.',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'master.create_supplier',
+            'executionPayload': {
+                'name': 'Eagle Fabrics',
+                'email': 'eagle@example.com',
+            },
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'master.create_supplier',
+                'entities': {
+                    'name': 'Eagle Fabrics',
+                    'email': 'eagle@example.com',
+                },
+                'missingFields': ['phone', 'address'],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'awaiting_confirmation',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.AWAITING_CONFIRMATION,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload'] == {
+        'name': 'Eagle Fabrics',
+        'email': 'eagle@example.com',
+        'phone': '020-765-4321',
+        'address': '45 Textile Lane, Liverpool.',
+    }
 
 
 async def test_runtime_service_handles_trace_attempts_without_crashing():
@@ -1568,6 +1670,207 @@ async def test_runtime_service_applies_po_clarification_reply_with_product_price
     assert any(block.type == BlockType.CONFIRMATION_REQUIRED for block in outcome.blocks)
 
 
+async def test_runtime_service_applies_po_color_correction_follow_up_without_replanning():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'TSHIRT-BLACK'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='go with sand',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'purchasing.create_po',
+            'executionPayload': {
+                'supplierId': 'Acme Supply',
+                'lines': [
+                    {
+                        'productName': 'Field Fresh Short',
+                        'colorName': 'Red',
+                        'sizeLabel': 'L',
+                        'quantity': 10,
+                    }
+                ],
+            },
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'purchasing.create_po',
+                'entities': {
+                    'supplierId': 'Acme Supply',
+                    'lines': [
+                        {
+                            'productName': 'Field Fresh Short',
+                            'colorName': 'Red',
+                            'sizeLabel': 'L',
+                            'quantity': 10,
+                        }
+                    ],
+                },
+                'missingFields': ['lines'],
+                'postActions': [],
+                'clarificationCount': 2,
+                'status': 'drafting',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload']['lines'] == [
+        {'sizeId': 'size-sand-l', 'qty': 10, 'unitCost': 42}
+    ]
+    assert any(block.type == BlockType.CONFIRMATION_REQUIRED for block in outcome.blocks)
+
+
+async def test_runtime_service_shows_variant_table_for_product_only_po_clarification():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'TSHIRT-BLACK'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='use this product',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'purchasing.create_po',
+            'executionPayload': {
+                'supplierId': 'Acme Supply',
+                'lines': [
+                    {
+                        'productName': 'Field Fresh Short',
+                        'quantity': 5,
+                    }
+                ],
+            },
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'purchasing.create_po',
+                'entities': {
+                    'supplierId': 'Acme Supply',
+                    'lines': [
+                        {
+                            'productName': 'Field Fresh Short',
+                            'quantity': 5,
+                        }
+                    ],
+                },
+                'missingFields': ['lines'],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.NEEDS_INPUT
+    assert any(block.type == BlockType.CLARIFICATION for block in outcome.blocks)
+    assert any(block.type == BlockType.TABLE_RESULT for block in outcome.blocks)
+    assert 'Which variant should I use?' in outcome.blocks[0].prompt
+
+
+async def test_runtime_service_applies_grouped_variant_follow_up_as_multiple_po_lines():
+    service = AgentRuntimeService(
+        backend_client=HarborVariantBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'TSHIRT-BLACK'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='sand xs,s,m,l,xl -10. navy xs,s,m,l,xl -20',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'purchasing.create_po',
+            'executionPayload': {
+                'supplierId': 'Acme Supply',
+                'lines': [
+                    {
+                        'productName': 'Harbor Intelligent Parka',
+                        'colorName': 'Red',
+                        'sizeLabel': 'XL',
+                        'quantity': 10,
+                        'unitCost': 10,
+                    }
+                ],
+            },
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'purchasing.create_po',
+                'entities': {
+                    'supplierId': 'Acme Supply',
+                    'lines': [
+                        {
+                            'productName': 'Harbor Intelligent Parka',
+                            'colorName': 'Red',
+                            'sizeLabel': 'XL',
+                            'quantity': 10,
+                            'unitCost': 10,
+                        }
+                    ],
+                },
+                'missingFields': ['lines'],
+                'postActions': [],
+                'clarificationCount': 2,
+                'status': 'drafting',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload']['lines'] == [
+        {'sizeId': 'size-sand-xs', 'qty': 10, 'unitCost': 10},
+        {'sizeId': 'size-sand-s', 'qty': 10, 'unitCost': 10},
+        {'sizeId': 'size-sand-m', 'qty': 10, 'unitCost': 10},
+        {'sizeId': 'size-sand-l', 'qty': 10, 'unitCost': 10},
+        {'sizeId': 'size-sand-xl', 'qty': 10, 'unitCost': 10},
+        {'sizeId': 'size-navy-xs', 'qty': 20, 'unitCost': 10},
+        {'sizeId': 'size-navy-s', 'qty': 20, 'unitCost': 10},
+        {'sizeId': 'size-navy-m', 'qty': 20, 'unitCost': 10},
+        {'sizeId': 'size-navy-l', 'qty': 20, 'unitCost': 10},
+        {'sizeId': 'size-navy-xl', 'qty': 20, 'unitCost': 10},
+    ]
+    assert any(block.type == BlockType.CONFIRMATION_REQUIRED for block in outcome.blocks)
+
+
 async def test_runtime_service_edits_pending_po_in_awaiting_approval_and_requests_variant_selection():
     service = AgentRuntimeService(
         backend_client=FakeBackendClient(),  # type: ignore[arg-type]
@@ -1971,7 +2274,7 @@ async def test_runtime_service_reviewer_clarification_uses_intent_specific_promp
     assert outcome.status == WorkflowStatus.NEEDS_INPUT
     assert (
         outcome.blocks[0].prompt
-        == 'Reply with the supplier name and PO lines in the format `SKUCODE/SIZE xQTY @UNIT_COST`, separated by commas.'
+        == 'Reply with the supplier plus the product, color, size, and quantity for each PO line. Unit cost is optional if you want to use the product default.'
     )
     assert outcome.missing_fields == ['supplier_id', 'lines']
 
@@ -2355,6 +2658,67 @@ async def test_runtime_service_recovers_get_last_po_from_sparse_executor_proposa
     assert any(block.type == BlockType.TEXT for block in outcome.blocks)
 
 
+async def test_runtime_service_recovers_create_po_from_sparse_executor_proposal_with_supplier_context():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeInvalidExecutor(),  # type: ignore[arg-type]
+        reviewer=FakeReviewer(message='Variants loaded.'),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'create a purchase order for Field Fresh Short': {
+                    'useActiveWorkflow': False,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'purchasing.create_po',
+                    'confidence': 0.96,
+                    'rationale': 'Purchase order creation request detected.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='create a purchase order for Field Fresh Short',
+        extracted_entities={
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'master.create_supplier',
+                'entities': {
+                    'supplierId': 'sup-1',
+                    'supplierName': 'Acme Supply',
+                },
+                'missingFields': [],
+                'postActions': [],
+                'clarificationCount': 0,
+                'status': 'completed',
+            }
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.COMPLETED,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.NEEDS_INPUT
+    assert outcome.extracted_entities['toolName'] == 'purchasing.create_po'
+    assert outcome.extracted_entities['executionPayload'] == {
+        'supplierId': 'sup-1',
+        'lines': [{'productName': 'Field Fresh Short'}],
+    }
+    assert any(block.type == BlockType.CLARIFICATION for block in outcome.blocks)
+    assert any(block.type == BlockType.TABLE_RESULT for block in outcome.blocks)
+
+
 def test_runtime_service_sanitizes_write_arguments_from_task_context_entities():
     tool_arguments = AgentRuntimeService._sanitize_tool_arguments(
         tool_name='sales.dispatch_invoice',
@@ -2491,6 +2855,81 @@ async def test_runtime_service_reuses_completed_po_supplier_for_new_po_follow_up
     assert outcome.extracted_entities['executionPayload']['supplierId'] == 'sup-1'
     assert outcome.extracted_entities['executionPayload']['lines'] == [
         {'sizeId': 'size-sand-m', 'qty': 7, 'unitCost': 18}
+    ]
+
+
+async def test_runtime_service_reuses_last_po_lines_when_user_confirms_same_details():
+    service = AgentRuntimeService(
+        backend_client=FakeBackendClient(),  # type: ignore[arg-type]
+        planner=FakePlanner(),
+        executor=FakeExecutor('inventory.stock_on_hand', {'sku': 'TSHIRT-BLACK'}),
+        reviewer=FakeReviewer(),
+        narrator=FakeNarrator(),  # type: ignore[arg-type]
+        state_updater=FakeStateUpdater(
+            {
+                'yes use same details': {
+                    'useActiveWorkflow': True,
+                    'primaryRoute': 'mutation',
+                    'primaryIntent': 'purchasing.create_po',
+                    'confidence': 0.95,
+                    'rationale': 'Reuse the previous purchase-order line set.',
+                    'entityPatches': {},
+                    'navigationQuery': None,
+                    'postActionQuery': None,
+                }
+            }
+        ),  # type: ignore[arg-type]
+        memory_service=FakeMemoryService(),  # type: ignore[arg-type]
+        training_data_service=FakeTrainingService(),  # type: ignore[arg-type]
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+    )
+
+    outcome = await service.execute(
+        auth=make_auth(),
+        conversation_id=uuid4(),
+        workflow_id=uuid4(),
+        user_message='yes use same details',
+        extracted_entities={
+            '_workflowEngine': 'runtime',
+            'toolName': 'purchasing.create_po',
+            'executionPayload': {
+                'supplierId': 'sup-1',
+                'lines': [
+                    {
+                        'productName': 'Harbor Intelligent Parka',
+                        'colorName': 'Red',
+                        'sizeLabel': 'XL',
+                        'quantity': 10,
+                        'unitCost': 10,
+                    }
+                ],
+            },
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'purchasing.create_po',
+                'entities': {
+                    'supplierId': 'sup-1',
+                    'lastPoLines': [
+                        {'sizeId': 'size-sand-m', 'qty': 7, 'unitCost': 18},
+                        {'sizeId': 'size-sand-l', 'qty': 7, 'unitCost': 18},
+                    ],
+                },
+                'missingFields': ['lines'],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            },
+        },
+        recent_messages=[],
+        workflow_status=WorkflowStatus.NEEDS_INPUT,
+        emit=lambda *_args, **_kwargs: None,
+        run_id=uuid4(),
+    )
+
+    assert outcome.status == WorkflowStatus.AWAITING_CONFIRMATION
+    assert outcome.extracted_entities['executionPayload']['lines'] == [
+        {'sizeId': 'size-sand-m', 'qty': 7, 'unitCost': 18},
+        {'sizeId': 'size-sand-l', 'qty': 7, 'unitCost': 18},
     ]
 
 

--- a/conversational-engine/tests/test_runtime_state_update.py
+++ b/conversational-engine/tests/test_runtime_state_update.py
@@ -42,6 +42,28 @@ async def test_state_update_detects_master_data_mutation_intents(message: str, e
     assert state.primary_intent == expected_intent
 
 
+@pytest.mark.parametrize(
+    ('message', 'expected_intent'),
+    [
+        ("what's the status of PO-0001", 'purchasing.get_po'),
+        ('list all open POs', 'purchasing.list_pos'),
+        ("what's the status of SO-0001", 'sales.get_invoice'),
+        ('list open sales orders', 'sales.list_invoices'),
+    ],
+)
+async def test_state_update_detects_commerce_read_intents(message: str, expected_intent: str):
+    state = await resolve_state_update(
+        user_message=message,
+        extracted_entities={},
+        recent_messages=[],
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+        state_updater=None,
+    )
+
+    assert state.primary_route == 'read'
+    assert state.primary_intent == expected_intent
+
+
 async def test_state_update_reuses_pending_location_creation_for_field_reply():
     state = await resolve_state_update(
         user_message='name : leicester\nlec-01\nwarehosue',
@@ -67,6 +89,30 @@ async def test_state_update_reuses_pending_location_creation_for_field_reply():
     assert state.extracted_entities['name'] == 'leicester'
     assert state.extracted_entities['code'] == 'lec-01'
     assert state.extracted_entities['type'] == 'warehouse'
+
+
+async def test_state_update_continues_draft_mutation_without_missing_field_aliases():
+    state = await resolve_state_update(
+        user_message='get it from the products',
+        extracted_entities={
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'purchasing.create_po',
+                'entities': {'supplierId': 'sup-1', 'lines': [{'productName': 'SHR-034', 'qty': 10}]},
+                'missingFields': [],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            }
+        },
+        recent_messages=[],
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+        state_updater=None,
+    )
+
+    assert state.is_workflow_edit is True
+    assert state.primary_route == 'mutation'
+    assert state.primary_intent == 'purchasing.create_po'
 
 
 def test_state_update_formats_preview_entities_into_recent_message_context():

--- a/conversational-engine/tests/test_runtime_state_update.py
+++ b/conversational-engine/tests/test_runtime_state_update.py
@@ -115,6 +115,37 @@ async def test_state_update_continues_draft_mutation_without_missing_field_alias
     assert state.primary_intent == 'purchasing.create_po'
 
 
+async def test_state_update_extracts_supplier_phone_and_address_without_overwriting_name():
+    state = await resolve_state_update(
+        user_message='Phone is 020-765-4321, address 45 Textile Lane, Liverpool.',
+        extracted_entities={
+            'taskContext': {
+                'primaryRoute': 'mutation',
+                'primaryIntent': 'master.create_supplier',
+                'entities': {
+                    'name': 'Eagle Fabrics',
+                    'email': 'eagle@example.com',
+                },
+                'missingFields': ['phone', 'address'],
+                'postActions': [],
+                'clarificationCount': 1,
+                'status': 'drafting',
+            }
+        },
+        recent_messages=[],
+        retrieval_service=FakeRetrievalService(),  # type: ignore[arg-type]
+        state_updater=None,
+    )
+
+    assert state.is_workflow_edit is True
+    assert state.primary_route == 'mutation'
+    assert state.primary_intent == 'master.create_supplier'
+    assert state.extracted_entities['name'] == 'Eagle Fabrics'
+    assert state.extracted_entities['email'] == 'eagle@example.com'
+    assert state.extracted_entities['phone'] == '020-765-4321'
+    assert state.extracted_entities['address'] == '45 Textile Lane, Liverpool.'
+
+
 def test_state_update_formats_preview_entities_into_recent_message_context():
     formatted = _format_recent_messages(
         [

--- a/conversational-engine/tests/test_tool_catalog.py
+++ b/conversational-engine/tests/test_tool_catalog.py
@@ -11,16 +11,27 @@ pytestmark = pytest.mark.anyio
 
 class FakeBackendClient:
     def __init__(self) -> None:
+        self.list_call_counts: dict[str, int] = {
+            'locations': 0,
+            'suppliers': 0,
+            'customers': 0,
+            'categories': 0,
+        }
         self.location_payloads: list[dict[str, object]] = []
         self.location_updates: list[tuple[str, dict[str, object]]] = []
         self.deleted_locations: list[str] = []
         self.payloads: list[dict[str, object]] = []
         self.invoice_payloads: list[dict[str, object]] = []
+        self.invoice_updates: list[tuple[str, dict[str, object]]] = []
         self.invoice_dispatch_payloads: list[tuple[str, dict[str, object]]] = []
         self.invoice_cancel_ids: list[str] = []
         self.po_payloads: list[dict[str, object]] = []
+        self.po_updates: list[tuple[str, dict[str, object]]] = []
         self.po_receive_payloads: list[tuple[str, dict[str, object]]] = []
         self.po_close_ids: list[str] = []
+        self.po_cancel_ids: list[str] = []
+        self.po_list_params: list[dict[str, object] | None] = []
+        self.invoice_list_params: list[dict[str, object] | None] = []
         self.receipt_payloads: list[dict[str, object]] = []
         self.write_off_payloads: list[dict[str, object]] = []
         self.supplier_payloads: list[dict[str, object]] = []
@@ -73,6 +84,14 @@ class FakeBackendClient:
         self.invoices = [
             {'id': 'inv-1', 'number': 'SO-0001', 'customerName': 'Bob Smith'},
         ]
+        self.invoice_detail = {
+            'id': 'inv-1',
+            'number': 'SO-0001',
+            'lines': [
+                {'id': 'inv-line-1', 'skuId': 'size-sand-l', 'qty': 5, 'unitPrice': 55},
+                {'id': 'inv-line-2', 'skuId': 'size-sand-m', 'qty': 3, 'unitPrice': 50},
+            ],
+        }
 
     async def create_product(self, access_token: str, tenant_id: str | None, payload: dict[str, object]):
         del access_token, tenant_id
@@ -108,6 +127,13 @@ class FakeBackendClient:
         self.invoice_dispatch_payloads.append((invoice_id, payload))
         return {'ok': True, 'invoiceId': invoice_id, 'payload': payload}
 
+    async def update_invoice(
+        self, access_token: str, tenant_id: str | None, invoice_id: str, payload: dict[str, object]
+    ):
+        del access_token, tenant_id
+        self.invoice_updates.append((invoice_id, payload))
+        return {'ok': True, 'invoiceId': invoice_id, 'payload': payload}
+
     async def cancel_invoice(self, access_token: str, tenant_id: str | None, invoice_id: str):
         del access_token, tenant_id
         self.invoice_cancel_ids.append(invoice_id)
@@ -117,6 +143,13 @@ class FakeBackendClient:
         del access_token, tenant_id
         self.po_payloads.append(payload)
         return {'ok': True, 'payload': payload}
+
+    async def update_po(
+        self, access_token: str, tenant_id: str | None, po_id: str, payload: dict[str, object]
+    ):
+        del access_token, tenant_id
+        self.po_updates.append((po_id, payload))
+        return {'ok': True, 'poId': po_id, 'payload': payload}
 
     async def receive_po(
         self, access_token: str, tenant_id: str | None, po_id: str, payload: dict[str, object]
@@ -128,6 +161,11 @@ class FakeBackendClient:
     async def close_po(self, access_token: str, tenant_id: str | None, po_id: str):
         del access_token, tenant_id
         self.po_close_ids.append(po_id)
+        return {'ok': True, 'poId': po_id}
+
+    async def cancel_po(self, access_token: str, tenant_id: str | None, po_id: str):
+        del access_token, tenant_id
+        self.po_cancel_ids.append(po_id)
         return {'ok': True, 'poId': po_id}
 
     async def receive_stock(self, access_token: str, tenant_id: str | None, payload: dict[str, object]):
@@ -176,18 +214,22 @@ class FakeBackendClient:
 
     async def list_locations(self, access_token: str, tenant_id: str | None):
         del access_token, tenant_id
+        self.list_call_counts['locations'] += 1
         return self.locations
 
     async def list_suppliers(self, access_token: str, tenant_id: str | None):
         del access_token, tenant_id
+        self.list_call_counts['suppliers'] += 1
         return self.suppliers
 
     async def list_customers(self, access_token: str, tenant_id: str | None):
         del access_token, tenant_id
+        self.list_call_counts['customers'] += 1
         return self.customers
 
     async def list_categories(self, access_token: str, tenant_id: str | None):
         del access_token, tenant_id
+        self.list_call_counts['categories'] += 1
         return self.categories
 
     async def search_products(self, access_token: str, tenant_id: str | None, q: str | None = None, **kwargs):
@@ -202,7 +244,8 @@ class FakeBackendClient:
         return self.product_detail
 
     async def list_pos(self, access_token: str, tenant_id: str | None, params: dict[str, object] | None = None):
-        del access_token, tenant_id, params
+        del access_token, tenant_id
+        self.po_list_params.append(params)
         return {'items': self.purchase_orders}
 
     async def get_po(self, access_token: str, tenant_id: str | None, po_id: str):
@@ -211,8 +254,44 @@ class FakeBackendClient:
         return self.purchase_order_detail
 
     async def list_invoices(self, access_token: str, tenant_id: str | None, params: dict[str, object] | None = None):
-        del access_token, tenant_id, params
+        del access_token, tenant_id
+        self.invoice_list_params.append(params)
         return {'items': self.invoices}
+
+    async def get_invoice(self, access_token: str, tenant_id: str | None, invoice_id: str):
+        del access_token, tenant_id
+        assert invoice_id == 'inv-1'
+        return self.invoice_detail
+
+
+class PaginatedProductBackendClient(FakeBackendClient):
+    async def search_products(self, access_token: str, tenant_id: str | None, q: str | None = None, **kwargs):
+        del access_token, tenant_id, kwargs
+        if not q:
+            return {'items': self.products, 'pagination': {'page': 1, 'pageSize': 50, 'total': len(self.products)}}
+        items = [product for product in self.products if q.lower() in str(product['name']).lower()]
+        return {'items': items, 'pagination': {'page': 1, 'pageSize': 50, 'total': len(items)}}
+
+
+class AmbiguousReferenceBackendClient(FakeBackendClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.suppliers = [
+            {'id': 'sup-1', 'name': 'Acme Supply', 'code': 'ACME'},
+            {'id': 'sup-3', 'name': 'Acme Source', 'code': 'ACMESRC'},
+        ]
+        self.customers = [
+            {'id': 'cust-2', 'name': 'Bob Smith', 'email': 'bob@example.com', 'code': 'BOB'},
+            {'id': 'cust-3', 'name': 'Bob Stone', 'email': 'bob.stone@example.com', 'code': 'BOBSTONE'},
+        ]
+        self.purchase_orders = [
+            {'id': 'po-1', 'number': 'PO-0001', 'supplierName': 'Acme Supply'},
+            {'id': 'po-2', 'number': 'PO-0002', 'supplierName': 'Acme Supply'},
+        ]
+        self.invoices = [
+            {'id': 'inv-1', 'number': 'SO-0001', 'customerName': 'Bob Smith'},
+            {'id': 'inv-2', 'number': 'SO-0002', 'customerName': 'Bob Smith'},
+        ]
 
 
 def make_auth() -> AuthContext:
@@ -390,6 +469,234 @@ async def test_purchase_order_create_normalizes_name_based_lines_for_backend():
     ]
 
 
+async def test_purchase_order_create_accepts_paginated_product_search_results():
+    backend = PaginatedProductBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    result = await catalog.invoke(
+        'purchasing.create_po',
+        {
+            'supplierId': 'Acme Supply',
+            'lines': [
+                {
+                    'productName': 'Field Fresh Short',
+                    'colorName': 'Sand',
+                    'sizeLabel': 'L',
+                    'quantity': 5,
+                    'unitCost': 21,
+                }
+            ],
+        },
+    )
+
+    assert result['result']['ok'] is True
+    assert backend.po_payloads == [
+        {
+            'supplierId': 'sup-1',
+            'lines': [{'sizeId': 'size-sand-l', 'qty': 5, 'unitCost': 21}],
+        }
+    ]
+
+
+async def test_purchase_order_create_defaults_missing_unit_cost_from_product_base_price():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    result = await catalog.invoke(
+        'purchasing.create_po',
+        {
+            'supplierId': 'Acme Supply',
+            'lines': [
+                {
+                    'productName': 'Field Fresh Short',
+                    'colorName': 'Sand',
+                    'sizeLabel': 'L',
+                    'quantity': 5,
+                }
+            ],
+        },
+    )
+
+    assert result['result']['ok'] is True
+    assert backend.po_payloads == [
+        {
+            'supplierId': 'sup-1',
+            'lines': [{'sizeId': 'size-sand-l', 'qty': 5, 'unitCost': 42}],
+        }
+    ]
+
+
+async def test_purchase_order_create_requests_variant_when_multiple_variants_exist():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    with pytest.raises(ToolPreparationError) as excinfo:
+        await catalog.prepare(
+            'purchasing.create_po',
+            {
+                'supplierId': 'Acme Supply',
+                'lines': [
+                    {
+                        'productName': 'Field Fresh Short',
+                        'quantity': 5,
+                    }
+                ],
+            },
+        )
+
+    assert 'Which variant should I use?' in excinfo.value.prompt
+    assert 'Sand / L' in excinfo.value.prompt
+    assert 'Clay / M' in excinfo.value.prompt
+
+
+async def test_purchase_order_create_requests_supplier_disambiguation_when_name_is_ambiguous():
+    backend = AmbiguousReferenceBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    with pytest.raises(ToolPreparationError) as excinfo:
+        await catalog.prepare(
+            'purchasing.create_po',
+            {
+                'supplierId': 'Acme S',
+                'lines': [
+                    {
+                        'productName': 'Field Fresh Short',
+                        'colorName': 'Sand',
+                        'sizeLabel': 'L',
+                        'quantity': 5,
+                        'unitCost': 21,
+                    }
+                ],
+            },
+        )
+
+    assert 'multiple suppliers' in excinfo.value.prompt.lower()
+    assert 'Acme Supply' in excinfo.value.prompt
+    assert 'Acme Source' in excinfo.value.prompt
+
+
+async def test_purchase_order_get_resolves_order_number():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    result = await catalog.invoke('purchasing.get_po', {'poId': 'PO-0001'})
+
+    assert result['result']['id'] == 'po-1'
+
+
+async def test_purchase_order_list_resolves_supplier_filter():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    result = await catalog.invoke('purchasing.list_pos', {'status': 'draft', 'supplierId': 'Acme Supply'})
+
+    assert result['result']['items'] == backend.purchase_orders
+    assert backend.po_list_params == [{'status': 'draft', 'supplierId': 'sup-1'}]
+
+
+async def test_purchase_order_get_prefers_exact_number_when_other_rows_share_supplier_name():
+    backend = AmbiguousReferenceBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    result = await catalog.invoke('purchasing.get_po', {'poId': 'PO-0001'})
+
+    assert result['result']['id'] == 'po-1'
+
+
+async def test_purchase_order_update_normalizes_header_patch_and_line_ops():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    result = await catalog.invoke(
+        'purchasing.update_po',
+        {
+            'poId': 'PO-0001',
+            'expectedDate': '2026-06-10T00:00:00Z',
+            'lineOps': [
+                {
+                    'op': 'change_qty',
+                    'lineRef': {'skuCode': 'sku-sand', 'sizeLabel': 'L'},
+                    'qty': 12,
+                },
+                {
+                    'op': 'add',
+                    'values': {
+                        'productName': 'Field Fresh Short',
+                        'colorName': 'Clay',
+                        'sizeLabel': 'M',
+                        'quantity': 4,
+                        'unitCost': 18,
+                    },
+                },
+            ],
+        },
+    )
+
+    assert result['result']['ok'] is True
+    assert backend.po_updates == [
+        (
+            'po-1',
+            {
+                'headerPatch': {'expectedDate': '2026-06-10T00:00:00Z'},
+                'lineOps': [
+                    {
+                        'op': 'change_qty',
+                        'lineRef': {'skuCode': 'sku-sand', 'sizeLabel': 'L'},
+                        'qty': 12,
+                    },
+                    {
+                        'op': 'add',
+                        'values': {'sizeId': 'size-clay-m', 'qty': 4, 'unitCost': 18},
+                    },
+                ],
+            },
+        )
+    ]
+
+
+async def test_purchase_order_update_resolves_line_number_refs():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    result = await catalog.invoke(
+        'purchasing.update_po',
+        {
+            'poId': 'PO-0001',
+            'lineOps': [
+                {
+                    'op': 'remove',
+                    'lineRef': {'lineNumber': 2},
+                },
+            ],
+        },
+    )
+
+    assert result['result']['ok'] is True
+    assert backend.po_updates == [
+        (
+            'po-1',
+            {
+                'lineOps': [
+                    {
+                        'op': 'remove',
+                        'lineRef': {'sizeId': 'size-clay-m'},
+                    },
+                ],
+            },
+        )
+    ]
+
+
+async def test_purchase_order_cancel_resolves_order_number():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    result = await catalog.invoke('purchasing.cancel_po', {'poId': 'PO-0001'})
+
+    assert result['result']['poId'] == 'po-1'
+    assert backend.po_cancel_ids == ['po-1']
+
+
 async def test_sales_create_invoice_normalizes_name_based_lines_for_backend():
     backend = FakeBackendClient()
     catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
@@ -425,7 +732,7 @@ async def test_sales_create_invoice_requires_color_and_size_when_product_is_ambi
     backend = FakeBackendClient()
     catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
 
-    with pytest.raises(ToolPreparationError, match='Color is required'):
+    with pytest.raises(ToolPreparationError, match='Which variant should I use'):
         await catalog.invoke(
             'sales.create_invoice',
             {
@@ -435,6 +742,160 @@ async def test_sales_create_invoice_requires_color_and_size_when_product_is_ambi
                 ],
             },
         )
+
+
+async def test_sales_get_invoice_resolves_order_number():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    result = await catalog.invoke('sales.get_invoice', {'invoiceId': 'SO-0001'})
+
+    assert result['result']['id'] == 'inv-1'
+
+
+async def test_sales_cancel_invoice_requests_order_disambiguation_when_customer_matches_multiple_orders():
+    backend = AmbiguousReferenceBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    with pytest.raises(ToolPreparationError) as excinfo:
+        await catalog.prepare('sales.cancel_invoice', {'invoiceId': 'Bob Smith'})
+
+    assert 'multiple sales orders' in excinfo.value.prompt.lower()
+    assert 'SO-0001' in excinfo.value.prompt
+    assert 'SO-0002' in excinfo.value.prompt
+
+
+async def test_sales_list_invoices_resolves_customer_filter():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    result = await catalog.invoke('sales.list_invoices', {'status': 'draft', 'customerId': 'bob@example.com'})
+
+    assert result['result']['items'] == backend.invoices
+    assert backend.invoice_list_params == [{'status': 'draft', 'customerId': 'cust-2'}]
+
+
+async def test_sales_update_invoice_normalizes_line_ops():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    result = await catalog.invoke(
+        'sales.update_invoice',
+        {
+            'invoiceId': 'SO-0001',
+            'lineOps': [
+                {
+                    'op': 'change_qty',
+                    'lineRef': {'skuCode': 'sku-sand', 'sizeLabel': 'M'},
+                    'qty': 15,
+                },
+                {
+                    'op': 'change_price',
+                    'lineRef': {'skuCode': 'sku-sand', 'sizeLabel': 'L'},
+                    'unitPrice': 60,
+                },
+            ],
+        },
+    )
+
+    assert result['result']['ok'] is True
+    assert backend.invoice_updates == [
+        (
+            'inv-1',
+            {
+                'lineOps': [
+                    {
+                        'op': 'change_qty',
+                        'lineRef': {'skuCode': 'sku-sand', 'sizeLabel': 'M'},
+                        'qty': 15,
+                    },
+                    {
+                        'op': 'change_price',
+                        'lineRef': {'skuCode': 'sku-sand', 'sizeLabel': 'L'},
+                        'unitPrice': 60,
+                    },
+                ]
+            },
+        )
+    ]
+
+
+async def test_sales_update_invoice_resolves_line_number_refs():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    result = await catalog.invoke(
+        'sales.update_invoice',
+        {
+            'invoiceId': 'SO-0001',
+            'lineOps': [
+                {
+                    'op': 'change_qty',
+                    'lineRef': {'lineNumber': 2},
+                    'qty': 9,
+                },
+            ],
+        },
+    )
+
+    assert result['result']['ok'] is True
+    assert backend.invoice_updates == [
+        (
+            'inv-1',
+            {
+                'lineOps': [
+                    {
+                        'op': 'change_qty',
+                        'lineRef': {'lineId': 'inv-line-2'},
+                        'qty': 9,
+                    },
+                ]
+            },
+        )
+    ]
+
+
+async def test_products_get_product_variants_lists_color_size_rows():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    result = await catalog.invoke('products.get_product_variants', {'product': 'Field Fresh Short'})
+
+    assert result['rows'] == [
+        {'sizeId': 'size-sand-l', 'skuId': 'sku-sand', 'colorName': 'Sand', 'sizeLabel': 'L'},
+        {'sizeId': 'size-sand-m', 'skuId': 'sku-sand', 'colorName': 'Sand', 'sizeLabel': 'M'},
+        {'sizeId': 'size-clay-l', 'skuId': 'sku-clay', 'colorName': 'Clay', 'sizeLabel': 'L'},
+        {'sizeId': 'size-clay-m', 'skuId': 'sku-clay', 'colorName': 'Clay', 'sizeLabel': 'M'},
+    ]
+
+
+async def test_entity_resolver_caches_repeated_customer_and_location_lookups():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    await catalog.prepare(
+        'sales.dispatch_invoice',
+        {
+            'invoiceId': 'SO-0001',
+            'locationId': 'Main Warehouse',
+        },
+    )
+    await catalog.prepare(
+        'master.delete_customer',
+        {
+            'customerId': 'bob@example.com',
+        },
+    )
+    await catalog.prepare(
+        'master.update_customer',
+        {
+            'customerId': 'bob@example.com',
+            'patch': {'phone': '12345'},
+        },
+    )
+
+    assert backend.list_call_counts['locations'] == 1
+    assert backend.list_call_counts['customers'] == 1
 
 
 async def test_inventory_receive_stock_expands_all_sizes_for_a_color():
@@ -552,6 +1013,19 @@ async def test_master_create_supplier_requires_name_and_keeps_optional_fields():
     assert backend.supplier_payloads == [{'name': 'Acme Supply', 'email': 'ops@acme.example', 'phone': '555-0101'}]
 
 
+async def test_master_create_supplier_normalizes_markdown_mailto_email():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    result = await catalog.invoke(
+        'master.create_supplier',
+        {'name': 'Raghu', 'email': '[raghu@bez.com](mailto:raghu@bez.com)'},
+    )
+
+    assert result['result']['ok'] is True
+    assert backend.supplier_payloads == [{'name': 'Raghu', 'email': 'raghu@bez.com'}]
+
+
 async def test_master_create_location_requires_core_fields_and_keeps_optional_fields():
     backend = FakeBackendClient()
     catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
@@ -578,6 +1052,19 @@ async def test_master_create_customer_accepts_optional_fields():
 
     assert result['result']['ok'] is True
     assert backend.customer_payloads == [{'name': 'Helen Barrows', 'email': 'helen41@yahoo.com', 'address': 'London'}]
+
+
+async def test_master_create_customer_normalizes_markdown_mailto_email():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    result = await catalog.invoke(
+        'master.create_customer',
+        {'name': 'Helen Barrows', 'email': '[helen41@yahoo.com](mailto:helen41@yahoo.com)'},
+    )
+
+    assert result['result']['ok'] is True
+    assert backend.customer_payloads == [{'name': 'Helen Barrows', 'email': 'helen41@yahoo.com'}]
 
 
 async def test_master_update_supplier_resolves_name_and_accepts_partial_patch():
@@ -702,3 +1189,122 @@ async def test_master_search_tools_return_filtered_rows(tool_name: str, query: s
     result = await catalog.invoke(tool_name, {'query': query})
 
     assert result == {'rows': expected}
+
+
+async def test_catalog_resolves_same_supplier_from_context_for_po_create():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(
+        backend=backend,
+        auth=make_auth(),
+        context_entities={'supplierId': 'sup-1', 'supplierName': 'Acme Supply'},
+    )  # type: ignore[arg-type]
+
+    prepared = await catalog.prepare(
+        'purchasing.create_po',
+        {
+            'supplierId': 'same supplier',
+            'lines': [{'productName': 'Field Fresh Short', 'colorName': 'Sand', 'sizeLabel': 'M', 'qty': 2}],
+        },
+    )
+
+    assert prepared['supplierId'] == 'sup-1'
+
+
+async def test_catalog_resolves_last_po_from_latest_list_item():
+    backend = FakeBackendClient()
+    backend.purchase_orders = [
+        {'id': 'po-9', 'number': 'PO-0009', 'supplierName': 'Beta Goods'},
+        {'id': 'po-1', 'number': 'PO-0001', 'supplierName': 'Acme Supply'},
+    ]
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    prepared = await catalog.prepare(
+        'purchasing.update_po',
+        {'poId': 'my last PO', 'expectedDate': '2026-05-30'},
+    )
+
+    assert prepared['poId'] == 'po-9'
+    assert prepared['headerPatch'] == {'expectedDate': '2026-05-30'}
+
+
+async def test_catalog_resolves_that_sales_order_from_context():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(
+        backend=backend,
+        auth=make_auth(),
+        context_entities={'invoiceId': 'inv-1', 'invoiceNumber': 'SO-0001'},
+    )  # type: ignore[arg-type]
+
+    prepared = await catalog.prepare(
+        'sales.dispatch_invoice',
+        {'invoiceId': 'that sales order', 'locationId': 'WH1'},
+    )
+
+    assert prepared['invoiceId'] == 'inv-1'
+    assert prepared['locationId'] == 'loc-1'
+
+
+async def test_catalog_relative_reference_requires_context_when_missing():
+    backend = FakeBackendClient()
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    with pytest.raises(
+        ToolPreparationError,
+        match='I do not have an active reference for "this sales order". Please specify the exact record.',
+    ):
+        await catalog.prepare(
+            'sales.dispatch_invoice',
+            {'invoiceId': 'that sales order', 'locationId': 'WH1'},
+        )
+
+
+async def test_catalog_resolves_last_po_for_supplier_from_latest_matching_item():
+    backend = FakeBackendClient()
+    backend.purchase_orders = [
+        {'id': 'po-9', 'number': 'PO-0009', 'supplierName': 'Beta Goods'},
+        {'id': 'po-7', 'number': 'PO-0007', 'supplierName': 'Acme Supply'},
+        {'id': 'po-1', 'number': 'PO-0001', 'supplierName': 'Acme Supply'},
+    ]
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    prepared = await catalog.prepare(
+        'purchasing.cancel_po',
+        {'poId': 'last PO for Acme Supply'},
+    )
+
+    assert prepared['poId'] == 'po-7'
+
+
+async def test_catalog_resolves_last_sales_order_for_customer_from_latest_matching_item():
+    backend = FakeBackendClient()
+    backend.invoices = [
+        {'id': 'inv-9', 'number': 'SO-0009', 'customerName': 'Alice Jones'},
+        {'id': 'inv-7', 'number': 'SO-0007', 'customerName': 'Bob Smith'},
+        {'id': 'inv-1', 'number': 'SO-0001', 'customerName': 'Bob Smith'},
+    ]
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    prepared = await catalog.prepare(
+        'sales.cancel_invoice',
+        {'invoiceId': 'last sales order for Bob Smith'},
+    )
+
+    assert prepared['invoiceId'] == 'inv-7'
+
+
+async def test_catalog_scoped_latest_reference_is_ambiguous_for_partial_party_match():
+    backend = FakeBackendClient()
+    backend.invoices = [
+        {'id': 'inv-7', 'number': 'SO-0007', 'customerName': 'Bob Smith'},
+        {'id': 'inv-6', 'number': 'SO-0006', 'customerName': 'Bob Stone'},
+    ]
+    catalog = SemanticToolCatalog(backend=backend, auth=make_auth())  # type: ignore[arg-type]
+
+    with pytest.raises(
+        ToolPreparationError,
+        match='I found multiple sales orders matching "Bob". Which sales order should I use\\?',
+    ):
+        await catalog.prepare(
+            'sales.cancel_invoice',
+            {'invoiceId': 'last sales order for Bob'},
+        )


### PR DESCRIPTION
## Summary

This PR completes the runtime-side commerce conversation fixes for purchasing and sales workflows.

It makes the runtime path the reliable execution layer for PO/SO creation, updates, follow-up edits, clarification handling, ambiguity resolution, and repeated-order reuse.

## What Changed

- added stronger PO/SO draft reuse across follow-up turns
- fixed clarification edits so color, size, quantity, phone, address, and cost updates patch the active draft correctly
- added grouped variant parsing for PO follow-ups such as multi-size and multi-color shorthand
- improved product variant clarification by showing available variants when product-only input is ambiguous
- fixed supplier/customer contact follow-up parsing so phone and address updates do not overwrite the name
- preserved and reused last confirmed PO line sets for `same details` follow-ups
- improved runtime recovery for sparse tool proposals and repeated commerce actions
- expanded runtime tests for clarification, variant selection, grouped line parsing, contact updates, and PO detail reuse


## Notes

This PR is focused on runtime-authoritative  conversation reliability, especially around:
- purchase order creation
- repeated purchase orders
- variant selection
- follow-up corrections
- supplier/customer detail carry-over
- clarification quality
